### PR TITLE
feat: return the removed item from upload/remove

### DIFF
--- a/upload-api/service/types.ts
+++ b/upload-api/service/types.ts
@@ -27,7 +27,7 @@ export interface Service {
   },
   upload: {
     add: ServiceMethod<UploadAdd, UploadAddResult, Failure>,
-    remove: ServiceMethod<UploadRemove, void, Failure>,
+    remove: ServiceMethod<UploadRemove, UploadRemoveResult | undefined, Failure>,
     list: ServiceMethod<UploadList, ListResponse<UploadListItem>, Failure>,
   }
 }
@@ -64,7 +64,7 @@ export interface StoreTable {
 export interface UploadTable {
   exists: (space: DID, root: AnyLink) => Promise<boolean>
   insert: (item: UploadAddInput) => Promise<UploadAddResult>
-  remove: (space: DID, root: AnyLink) => Promise<void>
+  remove: (space: DID, root: AnyLink) => Promise<UploadRemoveResult | undefined>
   list: (space: DID, options?: ListOptions) => Promise<ListResponse<UploadListItem>>
 }
 
@@ -100,6 +100,7 @@ export interface UploadAddInput {
 }
 
 export interface UploadAddResult extends Omit<UploadAddInput, 'space' | 'issuer' | 'invocation'> {}
+export interface UploadRemoveResult extends UploadAddResult {}
 
 export interface UploadListItem extends UploadAddResult {
   insertedAt: string

--- a/upload-api/service/upload/remove.js
+++ b/upload-api/service/upload/remove.js
@@ -3,12 +3,13 @@ import * as Upload from '@web3-storage/capabilities/upload'
 
 /**
  * @typedef {import('@web3-storage/capabilities/types').UploadRemove} UploadRemoveCapability
+ * @typedef {import('../types').UploadRemoveResult} UploadRemoveResult
  * @typedef {import('@ucanto/interface').Failure} Failure
  */
 
 /**
  * @param {import('../types').UploadServiceContext} context
- * @returns {import('@ucanto/interface').ServiceMethod<UploadRemoveCapability, void, Failure>}
+ * @returns {import('@ucanto/interface').ServiceMethod<UploadRemoveCapability, UploadRemoveResult | undefined, Failure>}
  */
 export function uploadRemoveProvider(context) {
   return Server.provide(
@@ -21,6 +22,6 @@ export function uploadRemoveProvider(context) {
       // We need to use https://github.com/web3-storage/w3protocol/blob/9d4b5bec1f0e870233b071ecb1c7a1e09189624b/packages/access/src/agent.js#L270
       const space = Server.DID.parse(capability.with).did()
 
-      await context.uploadTable.remove(space, root)
+      return context.uploadTable.remove(space, root)
   })
 }

--- a/upload-api/tables/upload.js
+++ b/upload-api/tables/upload.js
@@ -111,9 +111,16 @@ export function createUploadTable (region, tableName, options = {}) {
         Key: marshall({
           space,
           root: root.toString(),
-        })
+        }),
+        ReturnValues: 'ALL_OLD'
       })
-      await dynamoDb.send(cmd)
+      // return the removed object so caller may remove all shards
+      const res = await dynamoDb.send(cmd)
+      if (res.Attributes === undefined) {
+        return
+      }
+      const raw = unmarshall(res.Attributes)
+      return toUploadAddResult(raw)
     },
     /**
      * List all CARs bound to an account


### PR DESCRIPTION
Allows a caller to optionally call store/remove with the shards to completely remove a thing.

Needed by https://github.com/web3-storage/w3cli/pull/20

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>