### PR TITLE
chore: set correct sentry env and source maps

### DIFF
--- a/carpark/event-bus/eipfs-indexer.js
+++ b/carpark/event-bus/eipfs-indexer.js
@@ -7,6 +7,7 @@ const SQS_INDEXER_QUEUE_URL =
 const SQS_INDEXER_QUEUE_REGION = 'us-west-2'
 
 Sentry.AWSLambda.init({
+  environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
 })

--- a/carpark/functions/carpark-bucket-event.js
+++ b/carpark/functions/carpark-bucket-event.js
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/serverless'
 import { notifyBus } from '../event-bus/source.js'
 
 Sentry.AWSLambda.init({
+  environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
 })

--- a/replicator/functions/replicator.js
+++ b/replicator/functions/replicator.js
@@ -5,6 +5,7 @@ import { replicate } from '../index.js'
 import parseSqsEvent from '../utils/parse-sqs-event.js'
 
 Sentry.AWSLambda.init({
+  environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
 })

--- a/satnav/functions/satnav-bucket-event.js
+++ b/satnav/functions/satnav-bucket-event.js
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/serverless'
 import { notifyBus } from '../event-bus/source.js'
 
 Sentry.AWSLambda.init({
+  environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
 })

--- a/satnav/functions/satnav-writer.js
+++ b/satnav/functions/satnav-writer.js
@@ -6,6 +6,7 @@ import parseSqsEvent from '../utils/parse-sqs-event.js'
 import { writeSatnavIndex } from '../index.js'
 
 Sentry.AWSLambda.init({
+  environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
 })

--- a/stacks/index.js
+++ b/stacks/index.js
@@ -13,6 +13,9 @@ import { SatnavStack } from './satnav-stack.js'
 export default function (app) {
   app.setDefaultFunctionProps({
     runtime: 'nodejs16.x',
+    environment: {
+      NODE_OPTIONS: "--enable-source-maps",
+    },
     bundle: {
       format: 'esm',
     },

--- a/ucan-invocation/functions/ucan-bucket-event.js
+++ b/ucan-invocation/functions/ucan-bucket-event.js
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/serverless'
 import { notifyBus } from '../event-bus/source.js'
 
 Sentry.AWSLambda.init({
+  environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
 })

--- a/upload-api/functions/get.js
+++ b/upload-api/functions/get.js
@@ -4,6 +4,7 @@ import { Config } from '@serverless-stack/node/config/index.js'
 import { getServicePrincipal, getServiceSigner } from '../config.js'
 
 Sentry.AWSLambda.init({
+  environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
 })

--- a/upload-api/functions/ucan-invocation-router.js
+++ b/upload-api/functions/ucan-invocation-router.js
@@ -15,6 +15,7 @@ import { createUcantoServer } from '../service/index.js'
 import { Config } from '@serverless-stack/node/config/index.js'
 
 Sentry.AWSLambda.init({
+  environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
 })

--- a/upload-api/service/index.js
+++ b/upload-api/service/index.js
@@ -7,6 +7,7 @@ import { createStoreService } from './store/index.js'
 import { createUploadService } from './upload/index.js'
 
 Sentry.AWSLambda.init({
+  environment: process.env.SST_STAGE,
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
 })


### PR DESCRIPTION
pass SST_STAGE to sentry.environment so we can see errors per deployment in sentry dashboard
  - SST_STAGE is a magic env var set for all Functions. Source: https://github.com/serverless-stack/sst/blob/9854bbf09e82bb05dae24b76162c08a44540f67e/packages/resources/src/Function.ts#L989

enable sourcemaps so error reports are easier to read
  - setting `--enable-source-maps` should be suffcient per the docs: https://docs.sst.dev/advanced/source-maps

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>