### PR TITLE
fix: destroy buckets for PR builds

### DIFF
--- a/stacks/carpark-stack.js
+++ b/stacks/carpark-stack.js
@@ -8,7 +8,7 @@ import * as sqs from 'aws-cdk-lib/aws-sqs'
 
 import { BusStack } from './bus-stack.js'
 import { CARPARK_EVENT_BRIDGE_SOURCE_EVENT } from '../carpark/event-bus/source.js'
-import { getBucketName, setupSentry } from './config.js'
+import { getBucketConfig, setupSentry } from './config.js'
 
 /**
  * @param {import('@serverless-stack/resources').StackContext} properties
@@ -27,7 +27,7 @@ export function CarparkStack({ stack, app }) {
   const carparkBucket = new Bucket(stack, 'car-store', {
     cors: true,
     cdk: {
-      bucket: { bucketName: getBucketName('carpark', app.stage) }
+      bucket: getBucketConfig('carpark', app.stage)
     }
   })
 

--- a/stacks/carpark-stack.js
+++ b/stacks/carpark-stack.js
@@ -8,7 +8,7 @@ import * as sqs from 'aws-cdk-lib/aws-sqs'
 
 import { BusStack } from './bus-stack.js'
 import { CARPARK_EVENT_BRIDGE_SOURCE_EVENT } from '../carpark/event-bus/source.js'
-import { getConfig, setupSentry } from './config.js'
+import { getBucketName, setupSentry } from './config.js'
 
 /**
  * @param {import('@serverless-stack/resources').StackContext} properties
@@ -18,9 +18,6 @@ export function CarparkStack({ stack, app }) {
     srcPath: 'carpark'
   })
 
-  // @ts-expect-error "prod" | "dev" | "staging" only allowed for stage
-  const stackConfig = getConfig(stack.stage)
-
   // Setup app monitoring with Sentry
   setupSentry(app, stack)
 
@@ -29,7 +26,9 @@ export function CarparkStack({ stack, app }) {
 
   const carparkBucket = new Bucket(stack, 'car-store', {
     cors: true,
-    ...stackConfig.carparkBucketConfig,
+    cdk: {
+      bucket: { bucketName: getBucketName('carpark', app.stage) }
+    }
   })
 
   // Elastic IPFS event for indexing

--- a/stacks/config.js
+++ b/stacks/config.js
@@ -30,8 +30,8 @@ export function isPrBuild (stage) {
  */
 export function getBucketConfig(name, stage, version = 0){
   return {
-      autoDeleteObjects: isPrBuild(stage),
-      bucketName: getBucketName(name, stage, version)
+    bucketName: getBucketName(name, stage, version),
+    ...(isPrBuild(stage) && { autoDeleteObjects: true })
   }
 }
 

--- a/stacks/config.js
+++ b/stacks/config.js
@@ -8,9 +8,31 @@ import git from 'git-rev-sync'
  * @param {string} stage
  * @param {number} version
  */
-export function getBucketName(name, stage, version = 0) {
+export function getBucketName (name, stage, version = 0) {
   // e.g `carpark-prod-0` or `satnav-pr101-0`
   return `${name}-${stage}-${version}`
+}
+
+/**
+ * Is an ephemeral build?
+ *
+ * @param {string} stage
+ */
+export function isPrBuild (stage) {
+  if (!stage) throw new Error('stage must be provided')
+  return stage !== 'prod' && stage !== 'staging'
+}
+
+/**
+ * @param {string} name
+ * @param {string} stage
+ * @param {number} version
+ */
+export function getBucketConfig(name, stage, version = 0){
+  return {
+      autoDeleteObjects: isPrBuild(stage),
+      bucketName: getBucketName(name, stage, version)
+  }
 }
 
 /**

--- a/stacks/config.js
+++ b/stacks/config.js
@@ -1,4 +1,5 @@
-import { createRequire } from "module"
+import { RemovalPolicy } from 'aws-cdk-lib'
+import { createRequire } from 'module'
 import git from 'git-rev-sync'
 
 /**
@@ -31,7 +32,10 @@ export function isPrBuild (stage) {
 export function getBucketConfig(name, stage, version = 0){
   return {
     bucketName: getBucketName(name, stage, version),
-    ...(isPrBuild(stage) && { autoDeleteObjects: true })
+    ...(isPrBuild(stage) && {
+      autoDeleteObjects: true,
+      removalPolicy: RemovalPolicy.DESTROY
+    })
   }
 }
 

--- a/stacks/config.js
+++ b/stacks/config.js
@@ -1,88 +1,15 @@
-// TREAT THIS THE SAME AS AN ENV FILE
-// DO NOT INCLUDE SECRETS IN IT
-import { RemovalPolicy } from 'aws-cdk-lib'
-// import { LayerVersion } from 'aws-cdk-lib/aws-lambda'
 import { createRequire } from "module"
 import git from 'git-rev-sync'
 
-const stageConfigs = {
-  dev: {
-    bucketConfig: {
-      cdk: {
-        bucket: {
-          autoDeleteObjects: true,
-          removalPolicy: RemovalPolicy.DESTROY,
-        },
-      },
-    },
-    tableConfig: {
-      cdk: {
-        table: {
-          removalPolicy: RemovalPolicy.DESTROY,
-        },
-      },
-    },
-  },
-  staging: {
-    carparkBucketConfig: {
-      cdk: {
-        bucket: {
-          // Force name of bucket to be "carpark-staging-0" in staging.
-          bucketName: 'carpark-staging-0'
-        },
-      },
-    },
-    satnavBucketConfig: {
-      cdk: {
-        bucket: {
-          // Force name of bucket to be "satnav-staging-0" in staging.
-          bucketName: 'satnav-staging-0'
-        },
-      },
-    },
-    ucanBucketConfig: {
-      cdk: {
-        bucket: {
-          // Force name of bucket to be "ucan-staging-0" in staging.
-          bucketName: 'ucan-store-staging-0'
-        },
-      },
-    }
-  },
-  prod: {
-    carparkBucketConfig: {
-      cdk: {
-        bucket: {
-          // Force name of bucket to be "carpark-prod-0" in prod.
-          bucketName: 'carpark-prod-0'
-        },
-      },
-    },
-    satnavBucketConfig: {
-      cdk: {
-        bucket: {
-          // Force name of bucket to be "satnav-prod-0" in prod.
-          bucketName: 'satnav-prod-0'
-        },
-      },
-    },
-    ucanBucketConfig: {
-      cdk: {
-        bucket: {
-          // Force name of bucket to be "ucan-prod-0" in prod.
-          bucketName: 'ucan-store-prod-0'
-        },
-      },
-    }
-  },
-}
-
 /**
- * @param {'dev'|'staging'|'prod'} stage
- * @returns {{ carparkBucketConfig ?:any, satnavBucketConfig ?: any, ucanBucketConfig ?: any, tableConfig ?:any }}
+ * Get nicer bucket names
+ * @param {string} name
+ * @param {string} stage
+ * @param {number} version
  */
-export function getConfig(stage) {
-  return stageConfigs[stage] || stageConfigs.dev
+export function getBucketName(name, stage, version = 0) {
+  // e.g `carpark-prod-0` or `satnav-pr101-0`
+  return `${name}-${stage}-${version}`
 }
 
 /**

--- a/stacks/config.js
+++ b/stacks/config.js
@@ -3,6 +3,7 @@ import git from 'git-rev-sync'
 
 /**
  * Get nicer bucket names
+ *
  * @param {string} name
  * @param {string} stage
  * @param {number} version

--- a/stacks/index.js
+++ b/stacks/index.js
@@ -1,4 +1,4 @@
-import { Tags } from 'aws-cdk-lib'
+import { Tags, RemovalPolicy } from 'aws-cdk-lib'
 
 import { UploadApiStack } from './upload-api-stack.js'
 import { UploadDbStack } from './upload-db-stack.js'
@@ -11,6 +11,10 @@ import { SatnavStack } from './satnav-stack.js'
  * @param {import('@serverless-stack/resources').App} app
  */
 export default function (app) {
+  if (app.stage !== 'prod' && app.stage !== 'staging') {
+    // destroy buckets and tables for PR builds
+    app.setDefaultRemovalPolicy(RemovalPolicy.DESTROY)
+  }
   app.setDefaultFunctionProps({
     runtime: 'nodejs16.x',
     bundle: {

--- a/stacks/index.js
+++ b/stacks/index.js
@@ -6,12 +6,13 @@ import { UcanInvocationStack } from './ucan-invocation-stack.js'
 import { BusStack } from './bus-stack.js'
 import { CarparkStack } from './carpark-stack.js'
 import { SatnavStack } from './satnav-stack.js'
+import { isPrBuild } from './config.js'
 
 /**
  * @param {import('@serverless-stack/resources').App} app
  */
 export default function (app) {
-  if (app.stage !== 'prod' && app.stage !== 'staging') {
+  if (isPrBuild(app.stage)) {
     // destroy buckets and tables for PR builds
     app.setDefaultRemovalPolicy(RemovalPolicy.DESTROY)
   }

--- a/stacks/satnav-stack.js
+++ b/stacks/satnav-stack.js
@@ -8,7 +8,7 @@ import { Duration, aws_events as awsEvents } from 'aws-cdk-lib'
 
 import { BusStack } from './bus-stack.js'
 import { CarparkStack } from './carpark-stack.js'
-import { getBucketName, setupSentry } from './config.js'
+import { getBucketConfig, setupSentry } from './config.js'
 import { CARPARK_EVENT_BRIDGE_SOURCE_EVENT } from '../carpark/event-bus/source.js'
 
 /**
@@ -29,7 +29,7 @@ export function SatnavStack({ stack, app }) {
 
   const satnavBucket = new Bucket(stack, 'satnav-store', {
     cdk: {
-      bucket: { bucketName: getBucketName('satnav', app.stage) }
+      bucket: getBucketConfig('satnav', app.stage)
     }
   })
 

--- a/stacks/satnav-stack.js
+++ b/stacks/satnav-stack.js
@@ -8,7 +8,7 @@ import { Duration, aws_events as awsEvents } from 'aws-cdk-lib'
 
 import { BusStack } from './bus-stack.js'
 import { CarparkStack } from './carpark-stack.js'
-import { getConfig, setupSentry } from './config.js'
+import { getBucketName, setupSentry } from './config.js'
 import { CARPARK_EVENT_BRIDGE_SOURCE_EVENT } from '../carpark/event-bus/source.js'
 
 /**
@@ -19,9 +19,6 @@ export function SatnavStack({ stack, app }) {
     srcPath: 'satnav'
   })
 
-  // @ts-expect-error "prod" | "dev" | "staging" only allowed for stage
-  const stackConfig = getConfig(stack.stage)
-
   // Setup app monitoring with Sentry
   setupSentry(app, stack)
 
@@ -31,7 +28,9 @@ export function SatnavStack({ stack, app }) {
   const { eventBus } = use(BusStack)
 
   const satnavBucket = new Bucket(stack, 'satnav-store', {
-    ...stackConfig.satnavBucketConfig,
+    cdk: {
+      bucket: { bucketName: getBucketName('satnav', app.stage) }
+    }
   })
 
    // Side Index creation and write to Satnav

--- a/stacks/ucan-invocation-stack.js
+++ b/stacks/ucan-invocation-stack.js
@@ -7,7 +7,7 @@ import {
 import { Duration } from 'aws-cdk-lib'
 
 import { BusStack } from './bus-stack.js'
-import { getBucketName, setupSentry } from './config.js'
+import { getBucketConfig, setupSentry } from './config.js'
 
 /**
  * @param {import('@serverless-stack/resources').StackContext} properties
@@ -26,7 +26,7 @@ export function UcanInvocationStack({ stack, app }) {
   const ucanBucket = new Bucket(stack, 'ucan-store', {
     cors: true,
     cdk: {
-      bucket: { bucketName: getBucketName('ucan-store', app.stage) }
+      bucket: getBucketConfig('ucan-store', app.stage)
     }
   })
 

--- a/stacks/ucan-invocation-stack.js
+++ b/stacks/ucan-invocation-stack.js
@@ -7,7 +7,7 @@ import {
 import { Duration } from 'aws-cdk-lib'
 
 import { BusStack } from './bus-stack.js'
-import { getConfig, setupSentry } from './config.js'
+import { getBucketName, setupSentry } from './config.js'
 
 /**
  * @param {import('@serverless-stack/resources').StackContext} properties
@@ -17,9 +17,6 @@ export function UcanInvocationStack({ stack, app }) {
     srcPath: 'ucan-invocation'
   })
 
-  // @ts-expect-error "prod" | "dev" | "staging" only allowed for stage
-  const stackConfig = getConfig(stack.stage)
-
   // Setup app monitoring with Sentry
   setupSentry(app, stack)
 
@@ -28,7 +25,9 @@ export function UcanInvocationStack({ stack, app }) {
 
   const ucanBucket = new Bucket(stack, 'ucan-store', {
     cors: true,
-    ...stackConfig.ucanBucketConfig,
+    cdk: {
+      bucket: { bucketName: getBucketName('ucan-store', app.stage) }
+    }
   })
 
   // Trigger ucan store events when a CAR is put into the bucket.

--- a/stacks/upload-db-stack.js
+++ b/stacks/upload-db-stack.js
@@ -1,14 +1,12 @@
 import { Table } from '@serverless-stack/resources'
 
 import { storeTableProps, uploadTableProps } from '../upload-api/tables/index.js'
-import { getConfig, setupSentry } from './config.js'
+import { setupSentry } from './config.js'
 
 /**
  * @param {import('@serverless-stack/resources').StackContext} properties
  */
 export function UploadDbStack({ stack, app }) {
-  // @ts-expect-error "prod" | "dev" | "staging" only allowed for stage
-  const stackConfig = getConfig(stack.stage)
 
   // Setup app monitoring with Sentry
   setupSentry(app, stack)
@@ -17,19 +15,13 @@ export function UploadDbStack({ stack, app }) {
    * This table takes a stored CAR and makes an entry in the store table
    * Used by the store/* service capabilities.
    */
-   const storeTable = new Table(stack, 'store', {
-    ...storeTableProps,
-    ...stackConfig.tableConfig,
-  })
+   const storeTable = new Table(stack, 'store', storeTableProps)
 
   /**
    * This table maps stored CAR files (shards) to an upload root cid.
    * Used by the upload/* capabilities.
    */
-   const uploadTable = new Table(stack, 'upload', {
-    ...uploadTableProps,
-    ...stackConfig.tableConfig,
-  })
+   const uploadTable = new Table(stack, 'upload', uploadTableProps)
 
   return {
     storeTable,


### PR DESCRIPTION
set `app.setDefaultRemovalPolicy(RemovalPolicy.DESTROY)` where stage is not `prod` or `staging`
- stage names are defined in seed.run as `prod` and `staging` and `pr<###>` in the environment specific settings
- docs: https://docs.sst.dev/advanced/removal-policy#changing-the-removal-policy

Remove big old config object in favour of simpler functions
- bucket names will be identical for staging and prod.
- PR buckets will now have nice names too!

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>