### PR TITLE
fix: fix ucanBucketConsumer export

### DIFF
--- a/ucan-invocation/functions/ucan-bucket-event.js
+++ b/ucan-invocation/functions/ucan-bucket-event.js
@@ -20,4 +20,4 @@ async function handler(event) {
   return await notifyBus(event, bus, EVENT_BUS_ARN)
 }
 
-export const carparkBucketConsumer = Sentry.AWSLambda.wrapHandler(handler)
+export const ucanBucketConsumer = Sentry.AWSLambda.wrapHandler(handler)


### PR DESCRIPTION
must match the export the stack expects here: https://github.com/web3-storage/w3infra/blob/5ed9b190d6442fbce3e8d6421d9e6501d22e7ace/stacks/ucan-invocation-stack.js#L39

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>