### PR TITLE
feat: enforce max single put size

### DIFF
--- a/upload-api/service/store/add.js
+++ b/upload-api/service/store/add.js
@@ -1,6 +1,9 @@
 import * as Server from '@ucanto/server'
 import * as Store from '@web3-storage/capabilities/store'
 
+// https://docs.aws.amazon.com/AmazonS3/latest/userguide/upload-objects.html
+export const MAX_S3_PUT_SIZE = 5_000_000_000
+
 /**
  * @typedef {import('../types').AnyLink} Link
  * @typedef {import('@web3-storage/access/types').StoreAdd} StoreAddCapability
@@ -50,6 +53,12 @@ export function storeAddProvider(context) {
           with: space,
           link
         }
+      }
+
+      if (size > MAX_S3_PUT_SIZE) {
+        // checking this last, as larger CAR may alreaady exist in bucket from pinning service fetch.
+        // we only want to prevent this here so we dont give the user a PUT url they can't use.
+        return new Server.Failure(`Size must not exceed ${MAX_S3_PUT_SIZE}. Split CAR into smaller shards`)
       }
 
       const { url, headers } = await context.carStoreBucket.createUploadUrl(link, size)

--- a/upload-api/test/service/store.test.js
+++ b/upload-api/test/service/store.test.js
@@ -353,7 +353,7 @@ test('store/add disallowed if invocation fails access verification', async (t) =
   t.is(service.space.info.callCount, 1)
 })
 
-test.only('store/add fails when size to large to PUT', async (t) => {
+test('store/add fails when size to large to PUT', async (t) => {
   const { tableName, bucketName } = await prepareResources(t.context.dynamoClient, t.context.s3Client)
 
   const uploadService = await Signer.generate()


### PR DESCRIPTION
S3 max put size is 5GB, so we enforce that in store/add to avoid giving folks a PUT url they can't use.

see: https://docs.aws.amazon.com/AmazonS3/latest/userguide/upload-objects.html

fixes #97

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>