### PR TITLE
fix: verify space registered on upload add

### DIFF
--- a/upload-api/service/store/list.js
+++ b/upload-api/service/store/list.js
@@ -18,10 +18,6 @@ export function storeListProvider(context) {
     Store.list,
     async ({ capability }) => {
       const { cursor, size } = capability.nb
-
-      // Only use capability account for now to check if account is registered.
-      // This must change to access account/info!!
-      // We need to use https://github.com/web3-storage/w3protocol/blob/9d4b5bec1f0e870233b071ecb1c7a1e09189624b/packages/access/src/agent.js#L270
       const space = Server.DID.parse(capability.with).did()
 
       return await context.storeTable.list(space, {

--- a/upload-api/service/store/remove.js
+++ b/upload-api/service/store/remove.js
@@ -16,9 +16,6 @@ export function storeRemoveProvider(context) {
     Store.remove,
     async ({ capability }) => {
       const { link } = capability.nb
-      // Only use capability account for now to check if account is registered.
-      // This must change to access account/info!!
-      // We need to use https://github.com/web3-storage/w3protocol/blob/9d4b5bec1f0e870233b071ecb1c7a1e09189624b/packages/access/src/agent.js#L270
       const space = Server.DID.parse(capability.with).did()
 
       await context.storeTable.remove(space, link)

--- a/upload-api/service/types.ts
+++ b/upload-api/service/types.ts
@@ -42,7 +42,8 @@ export interface StoreServiceContext {
 
 export interface UploadServiceContext {
   uploadTable: UploadTable,
-  dudewhereBucket: DudewhereBucket
+  dudewhereBucket: DudewhereBucket,
+  access: AccessClient
 }
 
 export interface UcantoServerContext extends StoreServiceContext, UploadServiceContext {}

--- a/upload-api/service/upload/add.js
+++ b/upload-api/service/upload/add.js
@@ -17,11 +17,13 @@ export function uploadAddProvider(context) {
     Upload.add,
     async ({ capability, invocation }) => {
       const { root, shards } = capability.nb
-
-      // Only use capability account for now to check if account is registered.
-      // This must change to access account/info!!
-      // We need to use https://github.com/web3-storage/w3protocol/blob/9d4b5bec1f0e870233b071ecb1c7a1e09189624b/packages/access/src/agent.js#L270
       const space = Server.DID.parse(capability.with).did()
+      const issuer = invocation.issuer.did()
+      const isVerified = await context.access.verifyInvocation(invocation)
+
+      if (!isVerified) {
+        return new Server.Failure(`${issuer} is not delegated capability ${Upload.add.can} on ${space}`)
+      }
 
       const [res] = await Promise.all([
         // Store in Database

--- a/upload-api/service/upload/list.js
+++ b/upload-api/service/upload/list.js
@@ -17,10 +17,6 @@ export function uploadListProvider(context) {
     Upload.list,
     async ({ capability }) => {
       const { cursor, size } = capability.nb
-
-      // Only use capability account for now to check if account is registered.
-      // This must change to access account/info!!
-      // We need to use https://github.com/web3-storage/w3protocol/blob/9d4b5bec1f0e870233b071ecb1c7a1e09189624b/packages/access/src/agent.js#L270
       const space = Server.DID.parse(capability.with).did()
 
       return await context.uploadTable.list(space, {

--- a/upload-api/service/upload/remove.js
+++ b/upload-api/service/upload/remove.js
@@ -16,10 +16,6 @@ export function uploadRemoveProvider(context) {
     Upload.remove,
     async ({ capability }) => {
       const { root } = capability.nb
-
-      // Only use capability account for now to check if account is registered.
-      // This must change to access account/info!!
-      // We need to use https://github.com/web3-storage/w3protocol/blob/9d4b5bec1f0e870233b071ecb1c7a1e09189624b/packages/access/src/agent.js#L270
       const space = Server.DID.parse(capability.with).did()
 
       return context.uploadTable.remove(space, root)


### PR DESCRIPTION
We previously added verification for `store/add`. We talked about doing same for upload but we did not.

In the context of `store`, we did not add validation for `list` and `remove` given it needed prior validations of a space being registered for add operations. In `upload` we should do the same. Otherwise, there is a vector where we can have our upload table written with uncontrolled number of non existing rows.

Closes https://github.com/web3-storage/w3infra/issues/37