### PR TITLE
feat: data integrity using md5

### DIFF
--- a/replicator/test/helpers/context.js
+++ b/replicator/test/helpers/context.js
@@ -1,7 +1,11 @@
 import anyTest from 'ava'
 
+
 /**
- * @typedef {import("ava").TestFn<Awaited<any>>} TestAnyFn
+ * @typedef {object} TestContext
+ * @property {import('@aws-sdk/client-s3').S3Client} s3Client
+ *
+ * @typedef {import("ava").TestFn<Awaited<TestContext>>} TestAnyFn
  */
 
 // eslint-disable-next-line unicorn/prefer-export-from


### PR DESCRIPTION
We have `sha256` as an attribute in our bucket entries. This could enable us to use S3's `GetObjectAttributesCommand` to get the sha256 of this. However, we can't follow same pattern as `dotStorage workers` because CF Workers have an internal API for R2 that supports sha256, while S3 API is still [not](https://developers.cloudflare.com/r2/data-access/s3-api/api/) compatible.

Moved towards trying to integrate md5, with the assumption of ETag header having md5 https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html in it and that we can use S3 Client for R2 with   ✅ Content-MD5

We get md5 ETag in base16 (thanks docs for not mentioning this anywhere 😘) wrapped with quotation marks and S3 client for PutObjectCommand expects the base64-encoded 128-bit MD5 digest of the message (without the headers) according to [RFC 1864](https://datatracker.ietf.org/doc/html/rfc1864)

Closes https://github.com/web3-storage/w3infra/issues/58
