### PR TITLE
feat: add secondary index to store table

### DIFF
--- a/upload-api/tables/index.js
+++ b/upload-api/tables/index.js
@@ -13,6 +13,10 @@ export const storeTableProps = {
   },
   // space + link must be unique to satisfy index constraint
   primaryIndex: { partitionKey: 'space', sortKey: 'link' },
+  globalIndexes: {
+    // @ts-expect-error sst got an typo in its types for TableGlobalIndexProps.partitionKey
+    linkSpace: { partitionKey: 'link', sortKey: 'space' }
+  }
 }
 
 /** @type TableProps */


### PR DESCRIPTION
adds an index to the store table using link as the partition key as a possible fix for #95 to let us find all the records for a given CAR CID.

adds support for `gloablIndexes` to our dynamo test util, to convert the sst definition to a dynamo definition.

see: https://docs.sst.dev/constructs/Table#globalindexes
see: https://www.dynamodbguide.com/global-secondary-indexes

TODO
- [ ] add method to store so we can query by link
- [ ] add tests

License: MIT
Signed-off-by: Oli Evans <oli@protocol.ai>