### PR TITLE
test: integration tests setup

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -3,3 +3,6 @@
 # uncomment to try out deploying the api under a custom domain.
 # the value should match a hosted zone configured in route53 that your aws account has access to.
 # HOSTED_ZONE=up.dag.haus
+
+# uncomment to set SENTRY_DSN
+# SENTRY_DSN = ''

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist
 
 # local env files
 .env*.local
+.test-env.json

--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ Deployment is managed by [seed.run]. PR's are deployed automatically to `https:/
 
 The `main` branch is deployed to https://staging.up.web3.storage and staging builds are promoted to prod manually via the UI at https://console.seed.run
 
+## Integration tests
+
+Integration tests run by default on post-deploy stage of [seed.run] deployment pipeline. These integration tests will run with the deployed infrastructure for the given stages (PR / staging).
+
+It is also possible to run the integration tests with a development deploy of `sst`. For this, you can run:
+
+```
+npm run deploy
+npm run test-integration
+```
+
+Please notice that appropriate environment variables must be set for the development deploy.
+
 ### Environment Variables
 
 Ensure the following variables are set in the env when deploying
@@ -207,7 +220,6 @@ const cid = await uploadFile({
   proofs: agent.getProofs([store, upload]),
 }, file)
 ```
-
 
 [SST]: https://sst.dev
 [UCAN]: https://github.com/ucan-wg/spec/

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,8 @@
         "@serverless-stack/resources": "^1.18.0",
         "@tsconfig/node16": "^1.0.3",
         "@types/git-rev-sync": "^2.0.0",
+        "@web-std/fetch": "^4.1.0",
+        "ava": "^4.3.3",
         "git-rev-sync": "^3.0.2",
         "hd-scripts": "^3.0.2",
         "lint-staged": "^13.0.3",

--- a/package.json
+++ b/package.json
@@ -2,21 +2,25 @@
   "name": "w3infra",
   "version": "0.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "start": "sst start",
     "build": "sst build",
-    "deploy": "sst deploy",
+    "deploy": "sst deploy --outputs-file .test-env.json",
     "remove": "sst remove",
     "console": "sst console",
     "lint": "tsc && eslint '**/*.js'",
     "clean": "rm -rf dist node_modules package-lock.json ./*/{.cache,dist,node_modules}",
-    "test": "npm test -w upload-api -w carpark -w replicator -w satnav -w ucan-invocation"
+    "test": "npm test -w upload-api -w carpark -w replicator -w satnav -w ucan-invocation",
+    "test-integration": "ava --verbose --timeout=60s test/*.test.js"
   },
   "devDependencies": {
     "@serverless-stack/cli": "^1.18.0",
     "@serverless-stack/resources": "^1.18.0",
     "@tsconfig/node16": "^1.0.3",
     "@types/git-rev-sync": "^2.0.0",
+    "@web-std/fetch": "^4.1.0",
+    "ava": "^4.3.3",
     "git-rev-sync": "^3.0.2",
     "hd-scripts": "^3.0.2",
     "lint-staged": "^13.0.3",

--- a/test/helpers/context.js
+++ b/test/helpers/context.js
@@ -1,0 +1,8 @@
+import anyTest from 'ava'
+
+/**
+ * @typedef {import("ava").TestFn<Awaited<any>>} TestAnyFn
+ */
+
+// eslint-disable-next-line unicorn/prefer-export-from
+export const test  = /** @type {TestAnyFn} */ (anyTest)

--- a/test/helpers/deployment.js
+++ b/test/helpers/deployment.js
@@ -1,0 +1,7 @@
+import {
+  State
+} from "@serverless-stack/core"
+
+// Either seed.run deployment, or development deploy outputs-file
+// https://seed.run/docs/adding-a-post-deploy-phase.html#post-deploy-phase-environment
+export const stage = process.env.SEED_STAGE_NAME || State.getStage(process.cwd())

--- a/test/upload-api.test.js
+++ b/test/upload-api.test.js
@@ -1,0 +1,38 @@
+import { fetch } from '@web-std/fetch'
+import { createRequire } from 'module'
+import git from 'git-rev-sync'
+
+import { test } from './helpers/context.js'
+import { stage } from './helpers/deployment.js'
+
+test('GET /', async t => {
+  const apiEndpoint = getApiEndpoint()
+  const response = await fetch(apiEndpoint)
+  t.is(response.status, 200)
+})
+
+test('GET /version', async t => {
+  const apiEndpoint = getApiEndpoint()
+
+  const response = await fetch(`${apiEndpoint}/version`)
+  t.is(response.status, 200)
+
+  const body = await response.json()
+  t.is(body.env, stage)
+  t.is(body.commit, git.long('.'))
+})
+
+const getApiEndpoint = () => {
+  // CI/CD deployment
+  if (process.env.SEED_APP_NAME) {
+    return `https://${stage}.up.web3.storage`
+  }
+
+  const require = createRequire(import.meta.url)
+  const sst = require('../sst.json')
+  const testEnv = require('../.test-env.json')
+
+  // Get Upload API endpoint
+  const id = 'UploadApiStack'
+  return testEnv[`${stage}-${sst.name}-${id}`].ApiEndpoint
+}


### PR DESCRIPTION
This PR adds the basic setup for integration tests. It relies on https://seed.run/docs/adding-a-post-deploy-phase.html to run the integration tests once seed.run finishes its deploy. You can see output in: https://console.seed.run/dag-house/w3infra/activity/stages/pr122/builds/16/post-deploy In case post deploy [fails](https://console.seed.run/dag-house/w3infra/activity/stages/pr122/builds/15/post-deploy), it is marked as failing in github CI too 👍🏼 

After this approach is validated, we should in follow up PRs to the actual interesting integration tests. Such as, using w3up client to interact with upload API, and checking its dynamoDB, buckets, R2, etc to guarantee everything happened as expect.

By default, not running `integration tests` with normal unit tests script. Main reason for this is the way longer time needed with `sst deploy` to run. We can have this in CI only, and be able to easily replicate locally when we see errors in CI.

Alternatively, I tried to get tests to run in github action first. For this, attempted to use https://github.com/marketplace/actions/wait-for-github-deployment (as well as other similar actions), but looks like we can't get these to awake with seed.run releases (even though they in theory both use Github Check API 🤷🏼‍♂️ ). After not being able to get this to work, I found out the seed run post deploy trick. From one side, I would love to get these to run in Github Actions, but I also feel this is ok while we have deployment step also running in Seed.run. When (and if) we consider moving this to github as well, we will be able to quite easily make the integration tests also run in actions.

After merging:
- [ ] enable post deploy stage for all stages (except prod)