### PR TITLE
fix: eipfs indexer with environment variable arn

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ Bucket name to persist the CAR files of UCAN invocations handled by the service.
 
 Data source name for Sentry application monitoring service.
 
+### `EIPFS_INDEXER_SQS_ARN`
+
+AWS ARN for Elastic IPFS SQS indexer used to request Elastic IPFS to index given CAR files.
+
 ### Secrets
 
 Set production secrets in aws SSM via [`sst secrets`](https://docs.sst.dev/config#sst-secrets). The region must be set to the one you deploy that stage to

--- a/stacks/carpark-stack.js
+++ b/stacks/carpark-stack.js
@@ -23,6 +23,7 @@ export function CarparkStack({ stack, app }) {
 
   // Get eventBus reference
   const { eventBus } = use(BusStack)
+  const { EIPFS_INDEXER_SQS_ARN } = getEnv()
 
   const carparkBucket = new Bucket(stack, 'car-store', {
     cors: true,
@@ -37,7 +38,7 @@ export function CarparkStack({ stack, app }) {
       queue: sqs.Queue.fromQueueArn(
         stack,
         'indexer-topic',
-        'arn:aws:sqs:us-west-2:505595374361:indexer-topic'
+        EIPFS_INDEXER_SQS_ARN
       ),
     },
   })
@@ -80,4 +81,27 @@ export function CarparkStack({ stack, app }) {
   return {
     carparkBucket
   }
+}
+
+/**
+ * Get Env validating it is set.
+ */
+function getEnv() {
+  return {
+    EIPFS_INDEXER_SQS_ARN: mustGetEnv('EIPFS_INDEXER_SQS_ARN'),
+  }
+}
+
+/**
+ * 
+ * @param {string} name 
+ * @returns {string}
+ */
+function mustGetEnv (name) {
+  if (!process.env[name]) {
+    throw new Error(`Missing env var: ${name}`)
+  }
+
+  // @ts-expect-error there will always be a string there, but typescript does not believe
+  return process.env[name]
 }


### PR DESCRIPTION
This PR makes our carpark to rely on E-IPFS SQS for indexing based on a provided ENV variable. This way, we can setup dev/staging to use staging E-IPFS while prod to use prod one

[seed.run](https://console.seed.run/dag-house/w3infra/settings/stages/staging) environments were set with new Env var for all envs