### PR TITLE
stacks/index.js sets options.bundle.sourcemap = true

### DIFF
--- a/stacks/index.js
+++ b/stacks/index.js
@@ -24,6 +24,7 @@ export default function (app) {
     },
     bundle: {
       format: 'esm',
+      sourcemap: true,
     },
   })
   app.stack(BusStack)


### PR DESCRIPTION
Motivation:
* I invoked upload-api and got an error response. The error response had a stack trace, but the stack trace doesn't seem to be source-maps-aware
* attempt to configure the stack in a way that we get source-map-aware stack traces
