### PR TITLE
fix: ensure that paging forward and backward yields the same first page

### DIFF
--- a/upload-api/tables/store.js
+++ b/upload-api/tables/store.js
@@ -126,19 +126,19 @@ export function createStoreTable (region, tableName, options = {}) {
       const response = await dynamoDb.send(cmd)
 
       const results = response.Items?.map(i => toStoreListResult(unmarshall(i))) ?? []
-      const startCursor = results[0] ? results[0].link.toString() : undefined
+      const firstLinkCID = results[0] ? results[0].link.toString() : undefined
       // Get cursor of the item where list operation stopped (inclusive).
       // This value can be used to start a new operation to continue listing.
       const lastKey = response.LastEvaluatedKey && unmarshall(response.LastEvaluatedKey)
-      const endCursor = lastKey ? lastKey.link : undefined
+      const lastLinkCID = lastKey ? lastKey.link : undefined
 
       return {
         size: results.length,
+        startCursor: options.pre ? lastLinkCID : firstLinkCID,
+        endCursor: options.pre ? firstLinkCID : lastLinkCID,
         // cursor is deprecated and will be removed in a future version
-        cursor: endCursor,
-        startCursor,
-        endCursor,
-        results
+        cursor: options.pre ? firstLinkCID : lastLinkCID,
+        results: options.pre ? results.reverse() : results
       }
     }
   }

--- a/upload-api/tables/upload.js
+++ b/upload-api/tables/upload.js
@@ -150,21 +150,21 @@ export function createUploadTable (region, tableName, options = {}) {
       const response = await dynamoDb.send(cmd)
 
       /** @type {UploadListItem[]} */
-      const results = response.Items?.map(i => toUploadListItem(unmarshall(i))) || []
-      const startCursor = results[0] ? results[0].root.toString() : undefined
+      let results = response.Items?.map(i => toUploadListItem(unmarshall(i))) || []
+      const firstRootCID = results[0] ? results[0].root.toString() : undefined
 
       // Get cursor of the item where list operation stopped (inclusive).
       // This value can be used to start a new operation to continue listing.
       const lastKey = response.LastEvaluatedKey && unmarshall(response.LastEvaluatedKey)
-      const endCursor = lastKey ? lastKey.root : undefined
+      const lastRootCID = lastKey ? lastKey.root : undefined
 
       return {
         size: results.length,
+        startCursor: options.pre ? lastRootCID : firstRootCID,
+        endCursor: options.pre ? firstRootCID : lastRootCID,
         // cursor is deprecated and will be removed in a future version
-        cursor: endCursor,
-        startCursor,
-        endCursor,
-        results
+        cursor: options.pre ? firstRootCID : lastRootCID,
+        results: options.pre ? results.reverse() : results
       }
     },
   }


### PR DESCRIPTION
My implementation of paging has a seriously confusing bug - if you paged forward and then paged backward, the list you got after paging backward would look like the original list but have its start and end cursors reversed. It would also be in the reverse order. We knew about the reverse ordering but didn't catch its implications for cursors.

This happens because when you passed `pre`, Dynamo would evaluate and list keys in reverse order.

This all brought me around to the opinion that we should always list keys in the same order, and make sure we swap endCursor and startCursor when `pre` is passed.

This PR adds tests to ensure that paging forward once and then backward does indeed give the same list of keys, in the same order, with the same startCursor and endCursor.

The power of demos!