### PR TITLE
feat!: rename startCursor and endCursor to before and after

### DIFF
--- a/upload-api/service/types.ts
+++ b/upload-api/service/types.ts
@@ -121,10 +121,10 @@ export interface ListOptions {
 }
 
 export interface ListResponse<R> {
-  // cursor is deprecated in favor of endCursor and will be removed in a future version
+  // cursor and after should be identical
   cursor?: string,
-  startCursor?: string,
-  endCursor?: string,
+  before?: string,
+  after?: string,
   size: number,
   results: R[]
 }

--- a/upload-api/tables/store.js
+++ b/upload-api/tables/store.js
@@ -132,12 +132,13 @@ export function createStoreTable (region, tableName, options = {}) {
       const lastKey = response.LastEvaluatedKey && unmarshall(response.LastEvaluatedKey)
       const lastLinkCID = lastKey ? lastKey.link : undefined
 
+      const before = options.pre ? lastLinkCID : firstLinkCID
+      const after = options.pre ? firstLinkCID : lastLinkCID
       return {
         size: results.length,
-        startCursor: options.pre ? lastLinkCID : firstLinkCID,
-        endCursor: options.pre ? firstLinkCID : lastLinkCID,
-        // cursor is deprecated and will be removed in a future version
-        cursor: options.pre ? firstLinkCID : lastLinkCID,
+        before,
+        after: after,
+        cursor: after,
         results: options.pre ? results.reverse() : results
       }
     }

--- a/upload-api/tables/upload.js
+++ b/upload-api/tables/upload.js
@@ -158,12 +158,13 @@ export function createUploadTable (region, tableName, options = {}) {
       const lastKey = response.LastEvaluatedKey && unmarshall(response.LastEvaluatedKey)
       const lastRootCID = lastKey ? lastKey.root : undefined
 
+      const before = options.pre ? lastRootCID : firstRootCID
+      const after = options.pre ? firstRootCID : lastRootCID
       return {
         size: results.length,
-        startCursor: options.pre ? lastRootCID : firstRootCID,
-        endCursor: options.pre ? firstRootCID : lastRootCID,
-        // cursor is deprecated and will be removed in a future version
-        cursor: options.pre ? firstRootCID : lastRootCID,
+        before,
+        after,
+        cursor: after,
         results: options.pre ? results.reverse() : results
       }
     },

--- a/upload-api/test/service/store.test.js
+++ b/upload-api/test/service/store.test.js
@@ -601,7 +601,7 @@ test('store/list can be paginated with custom size', async (t) => {
       throw new Error('invocation failed', { cause: storeList })
     }
 
-    cursor = storeList.endCursor
+    cursor = storeList.after
     // Add page if it has size
     storeList.size && listPages.push(storeList.results)
   } while (cursor)
@@ -680,7 +680,7 @@ test('store/list can page backwards', async (t) => {
     proofs: [proof],
     nb: {
       size,
-      cursor: listResponse.endCursor
+      cursor: listResponse.after
     }
   }).execute(connection)
   if (secondListResponse.error) {
@@ -695,7 +695,7 @@ test('store/list can page backwards', async (t) => {
     proofs: [proof],
     nb: {
       size,
-      cursor: secondListResponse.startCursor,
+      cursor: secondListResponse.before,
       pre: true
     }
   }).execute(connection)
@@ -704,13 +704,13 @@ test('store/list can page backwards', async (t) => {
   }
 
   t.is(listResponse.results.length, 3)
-  // listResponse is the first page. we used its endCursor to get the second page, and then used the startCursor of the second
+  // listResponse is the first page. we used its after to get the second page, and then used the before of the second
   // page with the `pre` caveat to list the first page again. the results and cursors should remain the same.
   t.like(prevListResponse.results[0], listResponse.results[0])
   t.like(prevListResponse.results[1], listResponse.results[1])
   t.like(prevListResponse.results[2], listResponse.results[2])
-  t.is(prevListResponse.startCursor, listResponse.startCursor)
-  t.is(prevListResponse.endCursor, listResponse.endCursor)
+  t.is(prevListResponse.before, listResponse.before)
+  t.is(prevListResponse.after, listResponse.after)
 })
 
 /**

--- a/upload-api/test/service/upload.test.js
+++ b/upload-api/test/service/upload.test.js
@@ -715,7 +715,7 @@ test('upload/list can page backwards', async (t) => {
     proofs: [proof],
     nb: {
       size,
-      cursor: listResponse.endCursor
+      cursor: listResponse.after
     }
   }).execute(connection)
   if (secondListResponse.error) {
@@ -730,7 +730,7 @@ test('upload/list can page backwards', async (t) => {
     proofs: [proof],
     nb: {
       size,
-      cursor: secondListResponse.startCursor,
+      cursor: secondListResponse.before,
       pre: true
     }
   }).execute(connection)
@@ -741,13 +741,13 @@ test('upload/list can page backwards', async (t) => {
   t.is(listResponse.results.length, 3)
   t.is(prevListResponse.results.length, 3)
 
-  // listResponse is the first page. we used its endCursor to get the second page, and then used the startCursor of the second
+  // listResponse is the first page. we used its after to get the second page, and then used the before of the second
   // page with the `pre` caveat to list the first page again. the results and cursors should remain the same.
   t.like(prevListResponse.results[0], listResponse.results[0])
   t.like(prevListResponse.results[1], listResponse.results[1])
   t.like(prevListResponse.results[2], listResponse.results[2])
-  t.is(prevListResponse.startCursor, listResponse.startCursor)
-  t.is(prevListResponse.endCursor, listResponse.endCursor)
+  t.is(prevListResponse.before, listResponse.before)
+  t.is(prevListResponse.after, listResponse.after)
 
 })
 


### PR DESCRIPTION
After chatting with @alanshaw I did a quick survey of naming conventions for bidirectional paging. After reviewing the following:

- https://theburningmonk.com/2018/02/guys-were-doing-pagination-wrong/ - before/after
- https://gist.github.com/tspecht/f4b53e34a2ccf1bdef2c8fb9a475ca05 - startCursor/endCursor
- https://medium.com/hackernoon/bi-directional-cursor-pagination-with-react-js-relay-and-graphql-dc4ad6f9cbb0 before/after
- https://www.apollographql.com/docs/react/pagination/cursor-based/#relay-style-cursor-pagination before/after
- relay's official paging spec uses before/after - https://relay.dev/graphql/connections.htm

I proposed renaming `startCursor` and `endCursor` to `before` and` after` and de-deprecating cursor.

This results in a paging API that should feel ergonomic to developers expecting a single directional paging API (which typically uses `cursor`) and developers expecting a bidirectional paging API - `startCursor` and `endCursor` are definitely used for bidirectional paging, but, eg Relay seems to have moved to `before` and `after` away from `startCursor` and `endCursor`.

`before` and `after` also have the benefit of being more succinct.