### PR TITLE
fix: temporary fix for access log format to allow http gateway deploy

### DIFF
--- a/stacks/upload-api-stack.js
+++ b/stacks/upload-api-stack.js
@@ -66,6 +66,9 @@ export function UploadApiStack({ stack, app }) {
        'GET /error':   'functions/get.error',
        'GET /version': 'functions/get.version'
     },
+    accessLog: {
+      format:'{"requestTime":"$context.requestTime","requestId":"$context.requestId","httpMethod":"$context.httpMethod","path":"$context.path","routeKey":"$context.routeKey","status":$context.status,"responseLatency":$context.responseLatency,"integrationRequestId":"$context.integration.requestId","integrationStatus":"$context.integration.status","integrationLatency":"$context.integration.latency","integrationServiceStatus":"$context.integration.integrationStatus","ip":"$context.identity.sourceIp","userAgent":"$context.identity.userAgent"}'
+    }
   })
 
   stack.addOutputs({


### PR DESCRIPTION
Temporary fix for CI issue from https://github.com/serverless-stack/sst/issues/2587 as suggested in https://github.com/serverless-stack/sst/issues/2587#issuecomment-1455875437

The fix simply tweaks the `accessLog` format to not include the `cognitoIdentityId` like fix from sst https://github.com/serverless-stack/sst/pull/2602/files

In the meantime, hopefully sst team provides a fix for v1, or we need to work on landing our update https://github.com/web3-storage/w3infra/pull/152 . I started by trying to update, but after spending over 2 hours debugging random CI SegFaults and other deployment issues decided to punt on this for now. v2 is quite recent and maybe we should stay in v1 some more time given these SegFault errors are likely not related to our code...