### PR TITLE
fix: api prometheus bytes naming

### DIFF
--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -47,7 +47,7 @@ test('upload-api /metrics', async t => {
   t.is(response.status, 200)
 
   const body = await response.text()
-  t.truthy(body.includes('_size_total'))
+  t.truthy(body.includes('_bytes'))
 })
 
 // Integration test for all flow from uploading a file to Kinesis events consumers and replicator

--- a/upload-api/functions/metrics.js
+++ b/upload-api/functions/metrics.js
@@ -73,7 +73,7 @@ function createRegistry (ns = 'w3up') {
     registry,
     metrics: {
       size: new Prom.Counter({
-        name: `${ns}_size_total`,
+        name: `${ns}_bytes`,
         help: 'Total bytes associated with each invocation.',
         labelNames: ['can'],
         registers: [registry]


### PR DESCRIPTION
Per naming conventions