### PR TITLE
feat: ucan stream consumer system upload add count

### DIFF
--- a/stacks/ucan-invocation-stack.js
+++ b/stacks/ucan-invocation-stack.js
@@ -85,6 +85,17 @@ export function UcanInvocationStack({ stack, app }) {
     deadLetterQueue: metricsStoreAddSizeTotalDLQ.cdk.queue,
   })
 
+  // metrics upload/add count
+  const metricsUploadAddTotalDLQ = new Queue(stack, 'metrics-upload-add-total-dlq')
+  const metricsUploadAddTotalConsumer = new Function(stack, 'metrics-upload-add-total-consumer', {
+    environment: {
+      TABLE_NAME: adminMetricsTable.tableName
+    },
+    permissions: [adminMetricsTable],
+    handler: 'functions/metrics-upload-add-total.consumer',
+    deadLetterQueue: metricsUploadAddTotalDLQ.cdk.queue,
+  })
+
   // metrics upload/remove count
   const metricsUploadRemoveTotalDLQ = new Queue(stack, 'metrics-upload-remove-total-dlq')
   const metricsUploadRemoveTotalConsumer = new Function(stack, 'metrics-upload-remove-total-consumer', {
@@ -157,6 +168,14 @@ export function UcanInvocationStack({ stack, app }) {
         function: metricsStoreAddSizeTotalConsumer,
         // TODO: Set kinesis filters when supported by SST
         // https://github.com/serverless-stack/sst/issues/1407
+        cdk: {
+          eventSource: {
+            ...(getKinesisEventSourceConfig(stack))
+          }
+        }
+      },
+      metricsUploadAddTotalConsumer: {
+        function: metricsUploadAddTotalConsumer,
         cdk: {
           eventSource: {
             ...(getKinesisEventSourceConfig(stack))

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -79,6 +79,7 @@ test('w3infra integration flow', async t => {
   // Get metrics before upload
   const beforeOperationMetrics = await getMetrics(t)
   const beforeStoreAddTotal = beforeOperationMetrics.find(row => row.name === METRICS_NAMES.STORE_ADD_TOTAL)
+  const beforeUploadAddTotal = beforeOperationMetrics.find(row => row.name === METRICS_NAMES.UPLOAD_ADD_TOTAL)
   const beforeStoreAddSizeTotal = beforeOperationMetrics.find(row => row.name === METRICS_NAMES.STORE_ADD_SIZE_TOTAL)
 
   const s3Client = getAwsBucketClient()
@@ -187,10 +188,11 @@ test('w3infra integration flow', async t => {
   })
 
   // Check metrics were updated
-  if (beforeStoreAddSizeTotal && spaceBeforeUploadAddMetrics) {
+  if (beforeStoreAddSizeTotal && spaceBeforeUploadAddMetrics && beforeUploadAddTotal) {
     await pWaitFor(async () => {
       const afterOperationMetrics = await getMetrics(t)
       const afterStoreAddTotal = afterOperationMetrics.find(row => row.name === METRICS_NAMES.STORE_ADD_TOTAL)
+      const afterUploadAddTotal = afterOperationMetrics.find(row => row.name === METRICS_NAMES.UPLOAD_ADD_TOTAL)
       const afterStoreAddSizeTotal = afterOperationMetrics.find(row => row.name === METRICS_NAMES.STORE_ADD_SIZE_TOTAL)
       const spaceAfterUploadAddMetrics = await getSpaceMetrics(t, spaceDid, SPACE_METRICS_NAMES.UPLOAD_ADD_TOTAL)
       const spaceAfterStoreAddMetrics = await getSpaceMetrics(t, spaceDid, SPACE_METRICS_NAMES.STORE_ADD_TOTAL)
@@ -199,6 +201,7 @@ test('w3infra integration flow', async t => {
       if (stage === 'staging') {
         return (
           afterStoreAddTotal?.value >= beforeStoreAddTotal?.value + 1 &&
+          afterUploadAddTotal?.value === beforeUploadAddTotal?.value + 1 &&
           afterStoreAddSizeTotal?.value >= beforeStoreAddSizeTotal.value + carSize &&
           spaceAfterStoreAddMetrics?.value >= spaceBeforeStoreAddMetrics?.value + 1 &&
           spaceAfterUploadAddMetrics?.value >= spaceBeforeUploadAddMetrics?.value + 1
@@ -207,6 +210,7 @@ test('w3infra integration flow', async t => {
   
       return (
         afterStoreAddTotal?.value === beforeStoreAddTotal?.value + 1 &&
+        afterUploadAddTotal?.value === beforeUploadAddTotal?.value + 1 &&
         afterStoreAddSizeTotal?.value === beforeStoreAddSizeTotal.value + carSize &&
         spaceAfterStoreAddMetrics?.value === spaceBeforeStoreAddMetrics?.value + 1 &&
         spaceAfterUploadAddMetrics?.value === spaceBeforeUploadAddMetrics?.value + 1

--- a/ucan-invocation/functions/metrics-upload-add-total.js
+++ b/ucan-invocation/functions/metrics-upload-add-total.js
@@ -1,0 +1,46 @@
+import * as Sentry from '@sentry/serverless'
+
+import { createMetricsTable } from '../tables/metrics.js'
+import { parseKinesisEvent } from '../utils/parse-kinesis-event.js'
+import { UPLOAD_ADD } from '../constants.js'
+
+Sentry.AWSLambda.init({
+  environment: process.env.SST_STAGE,
+  dsn: process.env.SENTRY_DSN,
+  tracesSampleRate: 1.0,
+})
+
+const AWS_REGION = process.env.AWS_REGION || 'us-west-2'
+
+/**
+ * @param {import('aws-lambda').KinesisStreamEvent} event
+ */
+async function handler(event) {
+  const ucanInvocations = parseKinesisEvent(event)
+
+  const {
+    TABLE_NAME: tableName = '',
+    // set for testing
+    DYNAMO_DB_ENDPOINT: dbEndpoint,
+  } = process.env
+
+  await updateUploadAddTotal(ucanInvocations, {
+    metricsTable: createMetricsTable(AWS_REGION, tableName, {
+      endpoint: dbEndpoint
+    })
+  })
+}
+
+/**
+ * @param {import('../types').UcanInvocation[]} ucanInvocations
+ * @param {import('../types').TotalSizeCtx} ctx
+ */
+export async function updateUploadAddTotal (ucanInvocations, ctx) {
+  const invocationsWithUploadAdd = ucanInvocations.filter(
+    inv => inv.value.att.find(a => a.can === UPLOAD_ADD)
+  ).flatMap(inv => inv.value.att)
+
+  await ctx.metricsTable.incrementUploadAddTotal(invocationsWithUploadAdd)
+}
+
+export const consumer = Sentry.AWSLambda.wrapHandler(handler)

--- a/ucan-invocation/tables/metrics.js
+++ b/ucan-invocation/tables/metrics.js
@@ -120,5 +120,28 @@ export function createMetricsTable (region, tableName, options = {}) {
 
       await dynamoDb.send(updateCmd)
     }
+    ,
+    /**
+     * Increment total count from upload/add operations.
+     *
+     * @param {Capabilities} operationsInv
+     */
+    incrementUploadAddTotal: async (operationsInv) => {
+      const invTotalSize = operationsInv.length
+
+      const updateCmd = new UpdateItemCommand({
+        TableName: tableName,
+        UpdateExpression: `ADD #value :value`,
+          ExpressionAttributeNames: {'#value': 'value'},
+          ExpressionAttributeValues: {
+            ':value': { N: String(invTotalSize) },
+          },
+        Key: marshall({
+          name: METRICS_NAMES.UPLOAD_ADD_TOTAL
+        })
+      })
+
+      await dynamoDb.send(updateCmd)
+    }
   }
 }

--- a/ucan-invocation/test/functions/metrics-upload-add-total.test.js
+++ b/ucan-invocation/test/functions/metrics-upload-add-total.test.js
@@ -1,0 +1,168 @@
+import { testConsumer as test } from '../helpers/context.js'
+
+import * as Signer from '@ucanto/principal/ed25519'
+import * as UploadCapabilities from '@web3-storage/capabilities/upload'
+
+import { createDynamodDb } from '../helpers/resources.js'
+import { createSpace } from '../helpers/ucanto.js'
+import { randomCAR } from '../helpers/random.js'
+import { createDynamoTable, getItemFromTable} from '../helpers/tables.js'
+import { adminMetricsTableProps } from '../../tables/index.js'
+
+import { updateUploadAddTotal } from '../../functions/metrics-upload-add-total.js'
+import { createMetricsTable } from '../../tables/metrics.js'
+import { METRICS_NAMES } from '../../constants.js'
+
+const REGION = 'us-west-2'
+
+test.before(async t => {
+  // Dynamo DB
+  const {
+    client: dynamo,
+    endpoint: dbEndpoint
+  } = await createDynamodDb({ port: 8000 })
+
+  t.context.dbEndpoint = dbEndpoint
+  t.context.dynamoClient = dynamo
+})
+
+test('handles a batch of single invocation with upload/add', async t => {
+  const { tableName } = await prepareResources(t.context.dynamoClient)
+  const uploadService = await Signer.generate()
+  const alice = await Signer.generate()
+  const { spaceDid } = await createSpace(alice)
+  const car = await randomCAR(128)
+
+  const metricsTable = createMetricsTable(REGION, tableName, {
+    endpoint: t.context.dbEndpoint
+  })
+
+  const invocations = [{
+    carCid: car.cid.toString(),
+    value: {
+        att: [
+          UploadCapabilities.add.create({
+            with: spaceDid,
+            nb: {
+              root: car.cid,
+              shards: [car.cid]
+            }
+          })
+        ],
+        aud: uploadService.did(),
+        iss: alice.did()
+    },
+    ts: Date.now()
+  }]
+
+  // @ts-expect-error
+  await updateUploadAddTotal(invocations, {
+    metricsTable
+  })
+
+  const item = await getItemFromTable(t.context.dynamoClient, tableName, {
+    name: METRICS_NAMES.UPLOAD_ADD_TOTAL
+  })
+  t.truthy(item)
+  t.is(item?.name, METRICS_NAMES.UPLOAD_ADD_TOTAL)
+  t.is(item?.value, 1)
+})
+
+test('handles batch of single invocations with multiple upload/add attributes', async t => {
+  const { tableName } = await prepareResources(t.context.dynamoClient)
+  const uploadService = await Signer.generate()
+  const alice = await Signer.generate()
+  const { spaceDid } = await createSpace(alice)
+
+  const cars = await Promise.all(
+    Array.from({ length: 10 }).map(() => randomCAR(128))
+  )
+
+  const metricsTable = createMetricsTable(REGION, tableName, {
+    endpoint: t.context.dbEndpoint
+  })
+
+  const invocations = [{
+    carCid: cars[0].cid.toString(),
+    value: {
+      att: cars.map((car) => UploadCapabilities.add.create({
+        with: spaceDid,
+        nb: {
+          root: car.cid,
+          shards: [car.cid]
+        }
+      })),
+      aud: uploadService.did(),
+      iss: alice.did()
+    },
+    ts: Date.now()
+  }]
+
+  // @ts-expect-error
+  await updateUploadAddTotal(invocations, {
+    metricsTable
+  })
+
+  const item = await getItemFromTable(t.context.dynamoClient, tableName, {
+    name: METRICS_NAMES.UPLOAD_ADD_TOTAL
+  })
+
+  t.truthy(item)
+  t.is(item?.name, METRICS_NAMES.UPLOAD_ADD_TOTAL)
+  t.is(item?.value, cars.length)
+})
+
+test('handles a batch of single invocation without upload/add', async t => {
+  const { tableName } = await prepareResources(t.context.dynamoClient)
+  const uploadService = await Signer.generate()
+  const alice = await Signer.generate()
+  const { spaceDid } = await createSpace(alice)
+  const car = await randomCAR(128)
+
+  const metricsTable = createMetricsTable(REGION, tableName, {
+    endpoint: t.context.dbEndpoint
+  })
+
+  const invocations = [{
+    carCid: car.cid.toString(),
+    value: {
+        att: [
+          UploadCapabilities.remove.create({
+            with: spaceDid,
+            nb: {
+              root: car.cid,
+            }
+          })
+        ],
+        aud: uploadService.did(),
+        iss: alice.did()
+    },
+    ts: Date.now()
+  }]
+
+  // @ts-expect-error
+  await updateUploadAddTotal(invocations, {
+    metricsTable
+  })
+
+  const item = await getItemFromTable(t.context.dynamoClient, tableName, {
+    name: METRICS_NAMES.UPLOAD_ADD_TOTAL
+  })
+
+  t.truthy(item)
+  t.is(item?.name, METRICS_NAMES.UPLOAD_ADD_TOTAL)
+  t.is(item?.value, 0)
+})
+
+/**
+ * @param {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamoClient
+ */
+async function prepareResources (dynamoClient) {
+  const [ tableName ] = await Promise.all([
+    createDynamoTable(dynamoClient, adminMetricsTableProps),
+  ])
+
+  return {
+    tableName
+  }
+}

--- a/ucan-invocation/types.ts
+++ b/ucan-invocation/types.ts
@@ -6,6 +6,7 @@ export interface MetricsTable {
   incrementStoreAddTotal: (incrementSizeTotal: Capability<Ability, `${string}:${string}`, unknown>[]) => Promise<void>
   incrementStoreAddSizeTotal: (incrementSizeTotal: Capability<Ability, `${string}:${string}`, unknown>[]) => Promise<void>
   incrementStoreRemoveTotal: (incrementSizeTotal: Capability<Ability, `${string}:${string}`, unknown>[]) => Promise<void>
+  incrementUploadAddTotal: (incrementSizeTotal: Capability<Ability, `${string}:${string}`, unknown>[]) => Promise<void>
   incrementUploadRemoveTotal: (incrementSizeTotal: Capability<Ability, `${string}:${string}`, unknown>[]) => Promise<void>
 }
 


### PR DESCRIPTION
Part of metrics work https://github.com/web3-storage/w3infra/issues/117

Adds system total metrics for  `upload/add`. With these, we can track number of uploads linked to a space. As we agreed, once we land receipts we can revisit this to be associated with receipt to track uniqueness 