### PR TITLE
feat: ucan stream consumer space size track

### DIFF
--- a/stacks/ucan-invocation-stack.js
+++ b/stacks/ucan-invocation-stack.js
@@ -154,6 +154,28 @@ export function UcanInvocationStack({ stack, app }) {
     deadLetterQueue: spaceMetricsDLQ.cdk.queue,
   })
 
+  // store/add size
+  const spaceMetricsStoreAddSizeTotalConsumer = new Function(stack, 'space-metrics-store-add-size-total-consumer', {
+    environment: {
+      TABLE_NAME: spaceMetricsTable.tableName,
+      STORE_BUCKET_NAME: carparkBucket.bucketName,
+    },
+    permissions: [spaceMetricsTable, carparkBucket],
+    handler: 'functions/space-metrics-store-add-size-total.consumer',
+    deadLetterQueue: spaceMetricsDLQ.cdk.queue,
+  })
+
+  // store/remove size
+  const spaceMetricsStoreRemoveSizeTotalConsumer = new Function(stack, 'space-metrics-store-remove-size-total-consumer', {
+    environment: {
+      TABLE_NAME: spaceMetricsTable.tableName,
+      STORE_BUCKET_NAME: carparkBucket.bucketName,
+    },
+    permissions: [spaceMetricsTable, carparkBucket],
+    handler: 'functions/space-metrics-store-remove-size-total.consumer',
+    deadLetterQueue: spaceMetricsDLQ.cdk.queue,
+  })
+
   // create a kinesis stream
   const ucanStream = new KinesisStream(stack, 'ucan-stream', {
     cdk: {
@@ -234,6 +256,26 @@ export function UcanInvocationStack({ stack, app }) {
       },
       spaceMetricsStoreRemoveTotalConsumer: {
         function: spaceMetricsStoreRemoveTotalConsumer,
+        // TODO: Set kinesis filters when supported by SST
+        // https://github.com/serverless-stack/sst/issues/1407
+        cdk: {
+          eventSource: {
+            ...(getKinesisEventSourceConfig(stack))
+          }
+        }
+      },
+      spaceMetricsStoreAddSizeTotalConsumer: {
+        function: spaceMetricsStoreAddSizeTotalConsumer,
+        // TODO: Set kinesis filters when supported by SST
+        // https://github.com/serverless-stack/sst/issues/1407
+        cdk: {
+          eventSource: {
+            ...(getKinesisEventSourceConfig(stack))
+          }
+        }
+      },
+      spaceMetricsStoreRemoveSizeTotalConsumer: {
+        function: spaceMetricsStoreRemoveSizeTotalConsumer,
         // TODO: Set kinesis filters when supported by SST
         // https://github.com/serverless-stack/sst/issues/1407
         cdk: {

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -75,6 +75,7 @@ test('w3infra integration flow', async t => {
   // Get space metrics before upload
   const spaceBeforeUploadAddMetrics = await getSpaceMetrics(t, spaceDid, SPACE_METRICS_NAMES.UPLOAD_ADD_TOTAL)
   const spaceBeforeStoreAddMetrics = await getSpaceMetrics(t, spaceDid, SPACE_METRICS_NAMES.STORE_ADD_TOTAL)
+  const spaceBeforeStoreAddSizeMetrics = await getSpaceMetrics(t, spaceDid, SPACE_METRICS_NAMES.STORE_ADD_SIZE_TOTAL)
 
   // Get metrics before upload
   const beforeOperationMetrics = await getMetrics(t)
@@ -188,7 +189,7 @@ test('w3infra integration flow', async t => {
   })
 
   // Check metrics were updated
-  if (beforeStoreAddSizeTotal && spaceBeforeUploadAddMetrics && beforeUploadAddTotal) {
+  if (beforeStoreAddSizeTotal && spaceBeforeUploadAddMetrics && spaceBeforeStoreAddSizeMetrics && beforeUploadAddTotal) {
     await pWaitFor(async () => {
       const afterOperationMetrics = await getMetrics(t)
       const afterStoreAddTotal = afterOperationMetrics.find(row => row.name === METRICS_NAMES.STORE_ADD_TOTAL)
@@ -196,6 +197,7 @@ test('w3infra integration flow', async t => {
       const afterStoreAddSizeTotal = afterOperationMetrics.find(row => row.name === METRICS_NAMES.STORE_ADD_SIZE_TOTAL)
       const spaceAfterUploadAddMetrics = await getSpaceMetrics(t, spaceDid, SPACE_METRICS_NAMES.UPLOAD_ADD_TOTAL)
       const spaceAfterStoreAddMetrics = await getSpaceMetrics(t, spaceDid, SPACE_METRICS_NAMES.STORE_ADD_TOTAL)
+      const spaceAfterStoreAddSizeMetrics = await getSpaceMetrics(t, spaceDid, SPACE_METRICS_NAMES.STORE_ADD_SIZE_TOTAL)
   
       // If staging accept more broad condition given multiple parallel tests can happen there
       if (stage === 'staging') {
@@ -204,7 +206,8 @@ test('w3infra integration flow', async t => {
           afterUploadAddTotal?.value === beforeUploadAddTotal?.value + 1 &&
           afterStoreAddSizeTotal?.value >= beforeStoreAddSizeTotal.value + carSize &&
           spaceAfterStoreAddMetrics?.value >= spaceBeforeStoreAddMetrics?.value + 1 &&
-          spaceAfterUploadAddMetrics?.value >= spaceBeforeUploadAddMetrics?.value + 1
+          spaceAfterUploadAddMetrics?.value >= spaceBeforeUploadAddMetrics?.value + 1 &&
+          spaceAfterStoreAddSizeMetrics?.value >= spaceBeforeStoreAddSizeMetrics?.value + carSize
         )
       }
   
@@ -213,7 +216,8 @@ test('w3infra integration flow', async t => {
         afterUploadAddTotal?.value === beforeUploadAddTotal?.value + 1 &&
         afterStoreAddSizeTotal?.value === beforeStoreAddSizeTotal.value + carSize &&
         spaceAfterStoreAddMetrics?.value === spaceBeforeStoreAddMetrics?.value + 1 &&
-        spaceAfterUploadAddMetrics?.value === spaceBeforeUploadAddMetrics?.value + 1
+        spaceAfterUploadAddMetrics?.value === spaceBeforeUploadAddMetrics?.value + 1 &&
+        spaceAfterStoreAddSizeMetrics?.value === spaceBeforeStoreAddSizeMetrics?.value + carSize
       )
     })
   }

--- a/ucan-invocation/functions/space-metrics-store-add-size-total.js
+++ b/ucan-invocation/functions/space-metrics-store-add-size-total.js
@@ -1,0 +1,45 @@
+import * as Sentry from '@sentry/serverless'
+
+import { createCarStore } from '../buckets/car-store.js'
+import { createSpaceMetricsTable } from '../tables/space-metrics.js'
+import { parseKinesisEvent } from '../utils/parse-kinesis-event.js'
+import { STORE_ADD } from '../constants.js'
+
+Sentry.AWSLambda.init({
+  environment: process.env.SST_STAGE,
+  dsn: process.env.SENTRY_DSN,
+  tracesSampleRate: 1.0,
+})
+
+const AWS_REGION = process.env.AWS_REGION || 'us-west-2'
+
+/**
+ * @param {import('aws-lambda').KinesisStreamEvent} event
+ */
+async function handler(event) {
+  const ucanInvocations = parseKinesisEvent(event)
+
+  const {
+    TABLE_NAME: tableName = '',
+    STORE_BUCKET_NAME: storeBucketName = '',
+  } = process.env
+
+  await updateAddSizeTotal(ucanInvocations, {
+    spaceMetricsTable: createSpaceMetricsTable(AWS_REGION, tableName),
+    carStoreBucket: createCarStore(AWS_REGION, storeBucketName)
+  })
+}
+
+/**
+ * @param {import('../types').UcanInvocation[]} ucanInvocations
+ * @param {import('../types').MetricsBySpaceWithBucketCtx} ctx
+ */
+export async function updateAddSizeTotal (ucanInvocations, ctx) {
+  const invocationsWithStoreAdd = ucanInvocations.filter(
+    inv => inv.value.att.find(a => a.can === STORE_ADD)
+  ).flatMap(inv => inv.value.att)
+
+  await ctx.spaceMetricsTable.incrementStoreAddSizeTotal(invocationsWithStoreAdd)
+}
+
+export const consumer = Sentry.AWSLambda.wrapHandler(handler)

--- a/ucan-invocation/functions/space-metrics-store-remove-size-total.js
+++ b/ucan-invocation/functions/space-metrics-store-remove-size-total.js
@@ -1,0 +1,55 @@
+import * as Sentry from '@sentry/serverless'
+
+import { createCarStore } from '../buckets/car-store.js'
+import { createSpaceMetricsTable } from '../tables/space-metrics.js'
+import { parseKinesisEvent } from '../utils/parse-kinesis-event.js'
+import { STORE_REMOVE } from '../constants.js'
+
+Sentry.AWSLambda.init({
+  environment: process.env.SST_STAGE,
+  dsn: process.env.SENTRY_DSN,
+  tracesSampleRate: 1.0,
+})
+
+const AWS_REGION = process.env.AWS_REGION || 'us-west-2'
+
+/**
+ * @param {import('aws-lambda').KinesisStreamEvent} event
+ */
+async function handler(event) {
+  const ucanInvocations = parseKinesisEvent(event)
+
+  const {
+    TABLE_NAME: tableName = '',
+    STORE_BUCKET_NAME: storeBucketName = '',
+  } = process.env
+
+  await updateRemoveSizeTotal(ucanInvocations, {
+    spaceMetricsTable: createSpaceMetricsTable(AWS_REGION, tableName),
+    carStoreBucket: createCarStore(AWS_REGION, storeBucketName)
+  })
+}
+
+/**
+ * @param {import('../types').UcanInvocation[]} ucanInvocations
+ * @param {import('../types').MetricsBySpaceWithBucketCtx} ctx
+ */
+export async function updateRemoveSizeTotal (ucanInvocations, ctx) {
+  const invocationsWithStoreRemove = ucanInvocations.filter(
+    inv => inv.value.att.find(a => a.can === STORE_REMOVE)
+  ).flatMap(inv => inv.value.att)
+
+  // TODO: once we have receipts for store/remove, replace this
+  // Temporary adaptor to set size in invocation
+  for (const inv of invocationsWithStoreRemove) {
+    // @ts-ignore remove invocations always have link
+    const size = await ctx.carStoreBucket.getSize(inv.nb?.link)
+
+    // @ts-ignore
+    inv.nb.size = size
+  }
+
+  await ctx.spaceMetricsTable.incrementStoreRemoveSizeTotal(invocationsWithStoreRemove)
+}
+
+export const consumer = Sentry.AWSLambda.wrapHandler(handler)

--- a/ucan-invocation/test/functions/space-metrics-store-add-size-total.test.js
+++ b/ucan-invocation/test/functions/space-metrics-store-add-size-total.test.js
@@ -1,0 +1,337 @@
+import { testConsumerWithBucket as test } from '../helpers/context.js'
+
+import { PutObjectCommand } from '@aws-sdk/client-s3'
+import * as Signer from '@ucanto/principal/ed25519'
+import * as StoreCapabilities from '@web3-storage/capabilities/store'
+
+import { spaceMetricsTableProps } from '../../tables/index.js'
+import {
+  createDynamodDb,
+  createS3,
+  createBucket,
+} from '../helpers/resources.js'
+import { createDynamoTable, getItemFromTable} from '../helpers/tables.js'
+import { createSpace } from '../helpers/ucanto.js'
+import { randomCAR } from '../helpers/random.js'
+
+import { updateAddSizeTotal } from '../../functions/space-metrics-store-add-size-total.js'
+import { SPACE_METRICS_NAMES } from '../../constants.js'
+import { createSpaceMetricsTable } from '../../tables/space-metrics.js'
+import { createCarStore } from '../../buckets/car-store.js'
+
+const REGION = 'us-west-2'
+
+test.before(async t => {
+  // Dynamo DB
+  const {
+    client: dynamo,
+    endpoint: dbEndpoint
+  } = await createDynamodDb({ port: 8000 })
+
+  t.context.dbEndpoint = dbEndpoint
+  t.context.dynamoClient = dynamo
+
+  // S3
+  const { client, clientOpts } = await createS3()
+  t.context.s3 = client
+  t.context.s3Opts = clientOpts
+})
+
+test('handles a batch of single invocation with store/add', async t => {
+  const { tableName, bucketName } = await prepareResources(t.context.dynamoClient, t.context.s3)
+  const uploadService = await Signer.generate()
+  const alice = await Signer.generate()
+  const { spaceDid } = await createSpace(alice)
+  const car = await randomCAR(128)
+
+  // Put CAR to bucket
+  const putObjectCmd = new PutObjectCommand({
+    Key: `${car.cid.toString()}/${car.cid.toString()}.car`,
+    Bucket: bucketName,
+    Body: Buffer.from(
+      await car.arrayBuffer()
+    )
+  })
+  await t.context.s3.send(putObjectCmd)
+
+  const spaceMetricsTable = createSpaceMetricsTable(REGION, tableName, {
+    endpoint: t.context.dbEndpoint
+  })
+  const carStoreBucket = createCarStore(REGION, bucketName, t.context.s3Opts)
+
+  const invocations = [{
+    carCid: car.cid.toString(),
+    value: {
+      att: [
+        StoreCapabilities.add.create({
+          with: spaceDid,
+          nb: {
+            link: car.cid,
+            size: car.size
+          }
+        })
+      ],
+      aud: uploadService.did(),
+      iss: alice.did()
+    },
+    ts: Date.now()
+  }]
+
+  // @ts-expect-error
+  await updateAddSizeTotal(invocations, {
+    spaceMetricsTable,
+    carStoreBucket
+  })
+
+  const item = await getItemFromTable(t.context.dynamoClient, tableName, {
+    space: spaceDid,
+    name: SPACE_METRICS_NAMES.STORE_ADD_SIZE_TOTAL
+  })
+  t.truthy(item)
+  t.is(item?.value, car.size)
+  t.is(item?.space, spaceDid)
+})
+
+test('handles batch of single invocation with multiple store/add attributes', async t => {
+  const { tableName, bucketName } = await prepareResources(t.context.dynamoClient, t.context.s3)
+  const uploadService = await Signer.generate()
+  const alice = await Signer.generate()
+  const { spaceDid } = await createSpace(alice)
+
+  const cars = await Promise.all(
+    Array.from({ length: 10 }).map(() => randomCAR(128))
+  )
+  // Put CARs to bucket
+  await Promise.all(cars.map(async car => {
+    const putObjectCmd = new PutObjectCommand({
+      Key: `${car.cid.toString()}/${car.cid.toString()}.car`,
+      Bucket: bucketName,
+      Body: Buffer.from(
+        await car.arrayBuffer()
+      )
+    })
+    return t.context.s3.send(putObjectCmd)
+  }))
+
+  const spaceMetricsTable = createSpaceMetricsTable(REGION, tableName, {
+    endpoint: t.context.dbEndpoint
+  })
+  const carStoreBucket = createCarStore(REGION, bucketName, t.context.s3Opts)
+
+  const invocations = [{
+    carCid: cars[0].cid.toString(),
+    value: {
+      att: cars.map((car) => StoreCapabilities.add.create({
+        with: spaceDid,
+        nb: {
+          link: car.cid,
+          size: car.size
+        }
+      })),
+      aud: uploadService.did(),
+      iss: alice.did()
+    },
+    ts: Date.now()
+  }]
+
+  // @ts-expect-error
+  await updateAddSizeTotal(invocations, {
+    spaceMetricsTable,
+    carStoreBucket
+  })
+
+  const item = await getItemFromTable(t.context.dynamoClient, tableName, {
+    space: spaceDid,
+    name: SPACE_METRICS_NAMES.STORE_ADD_SIZE_TOTAL
+  })
+  t.truthy(item)
+  t.is(item?.value, cars.reduce((acc, c) => acc + c.size, 0))
+  t.is(item?.space, spaceDid)
+})
+
+test('handles batch of multiple invocations with store/add in same space', async t => {
+  const { tableName, bucketName } = await prepareResources(t.context.dynamoClient, t.context.s3)
+  const uploadService = await Signer.generate()
+  const alice = await Signer.generate()
+  const { spaceDid } = await createSpace(alice)
+
+  const cars = await Promise.all(
+    Array.from({ length: 10 }).map(() => randomCAR(128))
+  )
+  // Put CARs to bucket
+  await Promise.all(cars.map(async car => {
+    const putObjectCmd = new PutObjectCommand({
+      Key: `${car.cid.toString()}/${car.cid.toString()}.car`,
+      Bucket: bucketName,
+      Body: Buffer.from(
+        await car.arrayBuffer()
+      )
+    })
+    return t.context.s3.send(putObjectCmd)
+  }))
+
+  const spaceMetricsTable = createSpaceMetricsTable(REGION, tableName, {
+    endpoint: t.context.dbEndpoint
+  })
+  const carStoreBucket = createCarStore(REGION, bucketName, t.context.s3Opts)
+
+  const invocations = cars.map((car) => ({
+    carCid: car.cid.toString(),
+    value: {
+      att: [
+        StoreCapabilities.add.create({
+          with: spaceDid,
+          nb: {
+            link: car.cid,
+            size: car.size
+          }
+        })
+      ],
+      aud: uploadService.did(),
+      iss: alice.did()
+    },
+    ts: Date.now()
+  }))
+
+  // @ts-expect-error
+  await updateAddSizeTotal(invocations, {
+    spaceMetricsTable,
+    carStoreBucket
+  })
+
+  const item = await getItemFromTable(t.context.dynamoClient, tableName, {
+    space: spaceDid,
+    name: SPACE_METRICS_NAMES.STORE_ADD_SIZE_TOTAL
+  })
+  t.truthy(item)
+  t.is(item?.value, cars.reduce((acc, c) => acc + c.size, 0))
+  t.is(item?.space, spaceDid)
+})
+
+test('handles batch of multiple invocations with store/add in multiple spaces', async t => {
+  const { tableName, bucketName } = await prepareResources(t.context.dynamoClient, t.context.s3)
+  const uploadService = await Signer.generate()
+  const alice = await Signer.generate()
+  const spaces = await Promise.all(
+    Array.from({ length: 10 }).map(() => createSpace(alice))
+  )
+
+  const car = await randomCAR(128)
+  // Put CAR to bucket
+  const putObjectCmd = new PutObjectCommand({
+    Key: `${car.cid.toString()}/${car.cid.toString()}.car`,
+    Bucket: bucketName,
+    Body: Buffer.from(
+      await car.arrayBuffer()
+    )
+  })
+  await t.context.s3.send(putObjectCmd)
+
+  const spaceMetricsTable = createSpaceMetricsTable(REGION, tableName, {
+    endpoint: t.context.dbEndpoint
+  })
+  const carStoreBucket = createCarStore(REGION, bucketName, t.context.s3Opts)
+
+  const invocations = spaces.map(({ spaceDid }) => ({
+    carCid: car.cid.toString(),
+    value: {
+      att: [
+        StoreCapabilities.add.create({
+          with: spaceDid,
+          nb: {
+            link: car.cid,
+            size: car.size
+          }
+        })
+      ],
+      aud: uploadService.did(),
+      iss: alice.did()
+    },
+    ts: Date.now()
+  }))
+
+  // @ts-expect-error
+  await updateAddSizeTotal(invocations, {
+    spaceMetricsTable,
+    carStoreBucket
+  })
+
+  const items = await Promise.all(
+    spaces.map(({ spaceDid }) => getItemFromTable(t.context.dynamoClient, tableName, {
+      space: spaceDid,
+      name: SPACE_METRICS_NAMES.STORE_ADD_SIZE_TOTAL
+    }))
+  )
+  t.truthy(items)
+  t.is(items.length, spaces.length)
+
+  for (const item of items) {
+    t.is(item?.value, car.size)
+  }
+})
+
+
+test('errors handling batch of multiple invocations with more transactions than allowed', async t => {
+  const { tableName, bucketName } = await prepareResources(t.context.dynamoClient, t.context.s3)
+  const uploadService = await Signer.generate()
+  const alice = await Signer.generate()
+  const spaces = await Promise.all(
+    Array.from({ length: 105 }).map(() => createSpace(alice))
+  )
+
+  const car = await randomCAR(128)
+  // Put CAR to bucket
+  const putObjectCmd = new PutObjectCommand({
+    Key: `${car.cid.toString()}/${car.cid.toString()}.car`,
+    Bucket: bucketName,
+    Body: Buffer.from(
+      await car.arrayBuffer()
+    )
+  })
+  await t.context.s3.send(putObjectCmd)
+
+  const spaceMetricsTable = createSpaceMetricsTable(REGION, tableName, {
+    endpoint: t.context.dbEndpoint
+  })
+  const carStoreBucket = createCarStore(REGION, bucketName, t.context.s3Opts)
+
+  const invocations = spaces.map(({ spaceDid }) => ({
+    carCid: car.cid.toString(),
+    value: {
+      att: [
+        StoreCapabilities.add.create({
+          with: spaceDid,
+          nb: {
+            link: car.cid,
+            size: car.size
+          }
+        })
+      ],
+      aud: uploadService.did(),
+      iss: alice.did()
+    },
+    ts: Date.now()
+  }))
+
+  // @ts-expect-error
+  await t.throwsAsync(() => updateAddSizeTotal(invocations, {
+    spaceMetricsTable,
+    carStoreBucket
+  }))
+})
+
+/**
+ * @param {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamoClient
+ * @param {import('@aws-sdk/client-s3').S3Client} s3Client
+ */
+async function prepareResources (dynamoClient, s3Client) {
+  const [ tableName, bucketName ] = await Promise.all([
+    createDynamoTable(dynamoClient, spaceMetricsTableProps),
+    createBucket(s3Client)
+  ])
+
+  return {
+    tableName,
+    bucketName
+  }
+}

--- a/ucan-invocation/test/functions/space-metrics-store-remove-size-total.test.js
+++ b/ucan-invocation/test/functions/space-metrics-store-remove-size-total.test.js
@@ -1,0 +1,331 @@
+import { testConsumerWithBucket as test } from '../helpers/context.js'
+
+import { PutObjectCommand } from '@aws-sdk/client-s3'
+import * as Signer from '@ucanto/principal/ed25519'
+import * as StoreCapabilities from '@web3-storage/capabilities/store'
+
+import { spaceMetricsTableProps } from '../../tables/index.js'
+import {
+  createDynamodDb,
+  createS3,
+  createBucket,
+} from '../helpers/resources.js'
+import { createDynamoTable, getItemFromTable} from '../helpers/tables.js'
+import { createSpace } from '../helpers/ucanto.js'
+import { randomCAR } from '../helpers/random.js'
+
+import { updateRemoveSizeTotal } from '../../functions/space-metrics-store-remove-size-total.js'
+import { SPACE_METRICS_NAMES } from '../../constants.js'
+import { createSpaceMetricsTable } from '../../tables/space-metrics.js'
+import { createCarStore } from '../../buckets/car-store.js'
+
+const REGION = 'us-west-2'
+
+test.before(async t => {
+  // Dynamo DB
+  const {
+    client: dynamo,
+    endpoint: dbEndpoint
+  } = await createDynamodDb({ port: 8000 })
+
+  t.context.dbEndpoint = dbEndpoint
+  t.context.dynamoClient = dynamo
+
+  // S3
+  const { client, clientOpts } = await createS3()
+  t.context.s3 = client
+  t.context.s3Opts = clientOpts
+})
+
+test('handles a batch of single invocation with store/remove', async t => {
+  const { tableName, bucketName } = await prepareResources(t.context.dynamoClient, t.context.s3)
+  const uploadService = await Signer.generate()
+  const alice = await Signer.generate()
+  const { spaceDid } = await createSpace(alice)
+  const car = await randomCAR(128)
+  // Put CAR to bucket
+  const putObjectCmd = new PutObjectCommand({
+    Key: `${car.cid.toString()}/${car.cid.toString()}.car`,
+    Bucket: bucketName,
+    Body: Buffer.from(
+      await car.arrayBuffer()
+    )
+  })
+  await t.context.s3.send(putObjectCmd)
+
+  const spaceMetricsTable = createSpaceMetricsTable(REGION, tableName, {
+    endpoint: t.context.dbEndpoint
+  })
+  const carStoreBucket = createCarStore(REGION, bucketName, t.context.s3Opts)
+
+  const invocations = [{
+    carCid: car.cid.toString(),
+    value: {
+      att: [
+        StoreCapabilities.remove.create({
+          with: spaceDid,
+          nb: {
+            link: car.cid
+          }
+        })
+      ],
+      aud: uploadService.did(),
+      iss: alice.did()
+    },
+    ts: Date.now()
+  }]
+
+  // @ts-expect-error
+  await updateRemoveSizeTotal(invocations, {
+    spaceMetricsTable,
+    carStoreBucket
+  })
+
+  const item = await getItemFromTable(t.context.dynamoClient, tableName, {
+    space: spaceDid,
+    name: SPACE_METRICS_NAMES.STORE_REMOVE_SIZE_TOTAL
+  })
+  t.truthy(item)
+  t.is(item?.value, car.size)
+  t.is(item?.space, spaceDid)
+})
+
+test('handles batch of single invocation with multiple store/remove attributes', async t => {
+  const { tableName, bucketName } = await prepareResources(t.context.dynamoClient, t.context.s3)
+  const uploadService = await Signer.generate()
+  const alice = await Signer.generate()
+  const { spaceDid } = await createSpace(alice)
+
+  const cars = await Promise.all(
+    Array.from({ length: 10 }).map(() => randomCAR(128))
+  )
+  // Put CARs to bucket
+  await Promise.all(cars.map(async car => {
+    const putObjectCmd = new PutObjectCommand({
+      Key: `${car.cid.toString()}/${car.cid.toString()}.car`,
+      Bucket: bucketName,
+      Body: Buffer.from(
+        await car.arrayBuffer()
+      )
+    })
+    return t.context.s3.send(putObjectCmd)
+  }))
+
+  const spaceMetricsTable = createSpaceMetricsTable(REGION, tableName, {
+    endpoint: t.context.dbEndpoint
+  })
+  const carStoreBucket = createCarStore(REGION, bucketName, t.context.s3Opts)
+
+  const invocations = [{
+    carCid: cars[0].cid.toString(),
+    value: {
+      att: cars.map((car) => StoreCapabilities.remove.create({
+        with: spaceDid,
+        nb: {
+          link: car.cid
+        }
+      })),
+      aud: uploadService.did(),
+      iss: alice.did()
+    },
+    ts: Date.now()
+  }]
+
+  // @ts-expect-error
+  await updateRemoveSizeTotal(invocations, {
+    spaceMetricsTable,
+    carStoreBucket
+  })
+
+  const item = await getItemFromTable(t.context.dynamoClient, tableName, {
+    space: spaceDid,
+    name: SPACE_METRICS_NAMES.STORE_REMOVE_SIZE_TOTAL
+  })
+  t.truthy(item)
+  t.is(item?.value, cars.reduce((acc, c) => acc + c.size, 0))
+  t.is(item?.space, spaceDid)
+})
+
+test('handles batch of multiple invocations with store/remove in same space', async t => {
+  const { tableName, bucketName } = await prepareResources(t.context.dynamoClient, t.context.s3)
+  const uploadService = await Signer.generate()
+  const alice = await Signer.generate()
+  const { spaceDid } = await createSpace(alice)
+
+  const cars = await Promise.all(
+    Array.from({ length: 10 }).map(() => randomCAR(128))
+  )
+  // Put CARs to bucket
+  await Promise.all(cars.map(async car => {
+    const putObjectCmd = new PutObjectCommand({
+      Key: `${car.cid.toString()}/${car.cid.toString()}.car`,
+      Bucket: bucketName,
+      Body: Buffer.from(
+        await car.arrayBuffer()
+      )
+    })
+    return t.context.s3.send(putObjectCmd)
+  }))
+
+  const spaceMetricsTable = createSpaceMetricsTable(REGION, tableName, {
+    endpoint: t.context.dbEndpoint
+  })
+  const carStoreBucket = createCarStore(REGION, bucketName, t.context.s3Opts)
+
+  const invocations = cars.map((car) => ({
+    carCid: car.cid.toString(),
+    value: {
+      att: [
+        StoreCapabilities.remove.create({
+          with: spaceDid,
+          nb: {
+            link: car.cid
+          }
+        })
+      ],
+      aud: uploadService.did(),
+      iss: alice.did()
+    },
+    ts: Date.now()
+  }))
+
+  // @ts-expect-error
+  await updateRemoveSizeTotal(invocations, {
+    spaceMetricsTable,
+    carStoreBucket
+  })
+
+  const item = await getItemFromTable(t.context.dynamoClient, tableName, {
+    space: spaceDid,
+    name: SPACE_METRICS_NAMES.STORE_REMOVE_SIZE_TOTAL
+  })
+  t.truthy(item)
+  t.is(item?.value, cars.reduce((acc, c) => acc + c.size, 0))
+  t.is(item?.space, spaceDid)
+})
+
+test('handles batch of multiple invocations with store/remove in multiple spaces', async t => {
+  const { tableName, bucketName } = await prepareResources(t.context.dynamoClient, t.context.s3)
+  const uploadService = await Signer.generate()
+  const alice = await Signer.generate()
+  const spaces = await Promise.all(
+    Array.from({ length: 10 }).map(() => createSpace(alice))
+  )
+
+  const car = await randomCAR(128)
+  // Put CAR to bucket
+  const putObjectCmd = new PutObjectCommand({
+    Key: `${car.cid.toString()}/${car.cid.toString()}.car`,
+    Bucket: bucketName,
+    Body: Buffer.from(
+      await car.arrayBuffer()
+    )
+  })
+  await t.context.s3.send(putObjectCmd)
+
+  const spaceMetricsTable = createSpaceMetricsTable(REGION, tableName, {
+    endpoint: t.context.dbEndpoint
+  })
+  const carStoreBucket = createCarStore(REGION, bucketName, t.context.s3Opts)
+
+  const invocations = spaces.map(({ spaceDid }) => ({
+    carCid: car.cid.toString(),
+    value: {
+      att: [
+        StoreCapabilities.remove.create({
+          with: spaceDid,
+          nb: {
+            link: car.cid
+          }
+        })
+      ],
+      aud: uploadService.did(),
+      iss: alice.did()
+    },
+    ts: Date.now()
+  }))
+
+  // @ts-expect-error
+  await updateRemoveSizeTotal(invocations, {
+    spaceMetricsTable,
+    carStoreBucket
+  })
+
+  const items = await Promise.all(
+    spaces.map(({ spaceDid }) => getItemFromTable(t.context.dynamoClient, tableName, {
+      space: spaceDid,
+      name: SPACE_METRICS_NAMES.STORE_REMOVE_SIZE_TOTAL
+    }))
+  )
+  t.truthy(items)
+  t.is(items.length, spaces.length)
+
+  for (const item of items) {
+    t.is(item?.value, car.size)
+  }
+})
+
+
+test('errors handling batch of multiple invocations with more transactions than allowed', async t => {
+  const { tableName, bucketName } = await prepareResources(t.context.dynamoClient, t.context.s3)
+  const uploadService = await Signer.generate()
+  const alice = await Signer.generate()
+  const spaces = await Promise.all(
+    Array.from({ length: 105 }).map(() => createSpace(alice))
+  )
+
+  const car = await randomCAR(128)
+  // Put CAR to bucket
+  const putObjectCmd = new PutObjectCommand({
+    Key: `${car.cid.toString()}/${car.cid.toString()}.car`,
+    Bucket: bucketName,
+    Body: Buffer.from(
+      await car.arrayBuffer()
+    )
+  })
+  await t.context.s3.send(putObjectCmd)
+
+  const spaceMetricsTable = createSpaceMetricsTable(REGION, tableName, {
+    endpoint: t.context.dbEndpoint
+  })
+  const carStoreBucket = createCarStore(REGION, bucketName, t.context.s3Opts)
+
+  const invocations = spaces.map(({ spaceDid }) => ({
+    carCid: car.cid.toString(),
+    value: {
+        att: [
+          StoreCapabilities.remove.create({
+            with: spaceDid,
+            nb: {
+              link: car.cid
+            }
+          })
+        ],
+        aud: uploadService.did(),
+        iss: alice.did()
+    },
+    ts: Date.now()
+  }))
+
+  // @ts-expect-error
+  await t.throwsAsync(() => updateRemoveSizeTotal(invocations, {
+    spaceMetricsTable,
+    carStoreBucket
+  }))
+})
+
+/**
+ * @param {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamoClient
+ * @param {import('@aws-sdk/client-s3').S3Client} s3Client
+ */
+async function prepareResources (dynamoClient, s3Client) {
+  const [ tableName, bucketName ] = await Promise.all([
+    createDynamoTable(dynamoClient, spaceMetricsTableProps),
+    createBucket(s3Client)
+  ])
+
+  return {
+    tableName,
+    bucketName
+  }
+}

--- a/ucan-invocation/test/helpers/context.js
+++ b/ucan-invocation/test/helpers/context.js
@@ -1,18 +1,15 @@
 import anyTest from 'ava'
 
 /**
- * @typedef {object} TestContext
- * @property {import('@aws-sdk/client-s3').S3Client} s3Client
+ * @typedef {object} S3Context
+ * @property {import('@aws-sdk/client-s3').S3Client} s3
+ * @property {import('@aws-sdk/client-s3').ServiceInputTypes} s3Opts
  *
  * @typedef {object} TestConsumerContext
  * @property {string} dbEndpoint
  * @property {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamoClient
  * 
- * @typedef {object} S3Context
- * @property {import('@aws-sdk/client-s3').S3Client} s3
- * @property {import('@aws-sdk/client-s3').ServiceInputTypes} s3Opts
- * 
- * @typedef {import("ava").TestFn<Awaited<TestContext>>} TestAnyFn
+ * @typedef {import("ava").TestFn<Awaited<S3Context>>} TestAnyFn
  * @typedef {import("ava").TestFn<Awaited<TestConsumerContext>>} TestConsumerFn
  * @typedef {import("ava").TestFn<Awaited<TestConsumerContext & S3Context>>} TestConsumerWithBucketFn
  */

--- a/ucan-invocation/types.ts
+++ b/ucan-invocation/types.ts
@@ -27,6 +27,8 @@ export interface SpaceMetricsTable {
   incrementStoreAddCount: (storeAddInv: Capability<Ability, `${string}:${string}`, unknown>[]) => Promise<void>
   incrementStoreRemoveCount: (storeRemoveInv: Capability<Ability, `${string}:${string}`, unknown>[]) => Promise<void>
   incrementUploadAddCount: (uploadAddInv: Capability<Ability, `${string}:${string}`, unknown>[]) => Promise<void>
+  incrementStoreAddSizeTotal: (incrementSizeTotal: Capability<Ability, `${string}:${string}`, unknown>[]) => Promise<void>
+  incrementStoreRemoveSizeTotal: (incrementSizeTotal: Capability<Ability, `${string}:${string}`, unknown>[]) => Promise<void>
 }
 export interface SpaceMetricsTableCtx {
   spaceMetricsTable: SpaceMetricsTable
@@ -34,6 +36,10 @@ export interface SpaceMetricsTableCtx {
 
 export interface RemoveSizeCtx {
   metricsTable: MetricsTable
+  carStoreBucket: CarStoreBucket
+}
+export interface MetricsBySpaceWithBucketCtx {
+  spaceMetricsTable: SpaceMetricsTable
   carStoreBucket: CarStoreBucket
 }
 


### PR DESCRIPTION
Part of metrics work https://github.com/web3-storage/w3infra/issues/117

Adds space accumulated metric for `store/add` and `store/remove` size. With these, we can track total size of CARs requested for deletion. Until we have receipts, we will rely on the bucket to perform a Head request (given we do not have GC as well for now)
