### PR TITLE
feat: add new system metrics to metrics endpoint

### DIFF
--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -47,7 +47,22 @@ test('upload-api /metrics', async t => {
   t.is(response.status, 200)
 
   const body = await response.text()
-  t.truthy(body.includes('_bytes'))
+  /**
+   * # HELP w3up_bytes Total bytes associated with each invocation.
+   * # TYPE w3up_bytes counter
+   * w3up_bytes{can="store/add"} 0
+   * w3up_bytes{can="store/remove"} 0
+   */
+  t.is((body.match(/w3up_bytes/g) || []).length, 4)
+  /**
+   * # HELP w3up_invocations_total Total number of invocations.
+   * # TYPE w3up_invocations_total counter
+   * w3up_invocations_total{can="store/add"} 1
+   * w3up_invocations_total{can="store/remove"} 0
+   * w3up_invocations_total{can="upload/add"} 0
+   * w3up_invocations_total{can="upload/remove"} 1
+   */
+  t.is((body.match(/w3up_invocations_total/g) || []).length, 6)
 })
 
 // Integration test for all flow from uploading a file to Kinesis events consumers and replicator

--- a/ucan-invocation/constants.js
+++ b/ucan-invocation/constants.js
@@ -11,6 +11,7 @@ export const METRICS_NAMES = {
   STORE_ADD_TOTAL: `${STORE_ADD}-total`,
   STORE_ADD_SIZE_TOTAL: `${STORE_ADD}-size-total`,
   STORE_REMOVE_TOTAL: `${STORE_REMOVE}-total`,
+  STORE_REMOVE_SIZE_TOTAL: `${STORE_REMOVE}-size-total`,
 }
 
 // Spade Metrics


### PR DESCRIPTION
Adds other system metrics to metrics endpoint

```
# HELP w3up_bytes Total bytes associated with each invocation.
# TYPE w3up_bytes counter
w3up_bytes{can="store/add"} 197
w3up_bytes{can="store/remove"} 0

# HELP w3up_invocations_total Total number of invocations.
# TYPE w3up_invocations_total counter
w3up_invocations_total{can="store/add"} 1
w3up_invocations_total{can="store/remove"} 0
w3up_invocations_total{can="upload/add"} 0
w3up_invocations_total{can="upload/remove"} 1
```

See https://pr165.up.web3.storage/metrics ✨ 

Needs:
- [x] https://github.com/web3-storage/w3infra/pull/159