### PR TITLE
fix: metrics http api handler accepting trailing slash

### DIFF
--- a/stacks/upload-api-stack.js
+++ b/stacks/upload-api-stack.js
@@ -67,6 +67,8 @@ export function UploadApiStack({ stack, app }) {
        'GET /error':   'functions/get.error',
        'GET /version': 'functions/get.version',
        'GET /metrics': 'functions/metrics.handler',
+       // AWS API Gateway does not know trailing slash... and Grafana Agent puts trailing slash
+       'GET /metrics/{proxy+}': 'functions/metrics.handler',
     },
     accessLog: {
       format:'{"requestTime":"$context.requestTime","requestId":"$context.requestId","httpMethod":"$context.httpMethod","path":"$context.path","routeKey":"$context.routeKey","status":$context.status,"responseLatency":$context.responseLatency,"integrationRequestId":"$context.integration.requestId","integrationStatus":"$context.integration.status","integrationLatency":"$context.integration.latency","integrationServiceStatus":"$context.integration.integrationStatus","ip":"$context.identity.sourceIp","userAgent":"$context.identity.userAgent"}'


### PR DESCRIPTION
AWS API Gateway does not know trailing slash... and Grafana Agent puts trailing slash

See:
- https://repost.aws/questions/QUuoQUNhpDRxWufwWJKIU6Uw/can-you-invoke-api-gateway-with-just-a-hostname-and-without-a-trailing-slash
- https://forum.serverless.com/t/switching-to-http-api-and-trailing-slash-issue/12717