### PR TITLE
fix: ucan stream checking receipt output

### DIFF
--- a/ucan-invocation/functions/metrics-store-add-size-total.js
+++ b/ucan-invocation/functions/metrics-store-add-size-total.js
@@ -1,8 +1,9 @@
 import * as Sentry from '@sentry/serverless'
 
 import { createMetricsTable } from '../tables/metrics.js'
+import { hasOkReceipt } from '../utils/receipt.js'
 import { parseKinesisEvent } from '../utils/parse-kinesis-event.js'
-import { STORE_ADD, STREAM_TYPE } from '../constants.js'
+import { STORE_ADD } from '../constants.js'
 
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
@@ -37,7 +38,7 @@ async function handler(event) {
  */
 export async function updateSizeTotal (ucanInvocations, ctx) {
   const invocationsWithStoreAdd = ucanInvocations.filter(
-    inv => inv.value.att.find(a => a.can === STORE_ADD) && inv.type === STREAM_TYPE.RECEIPT
+    inv => inv.value.att.find(a => a.can === STORE_ADD) && hasOkReceipt(inv)
   ).flatMap(inv => inv.value.att)
 
   await ctx.metricsTable.incrementStoreAddSizeTotal(invocationsWithStoreAdd)

--- a/ucan-invocation/functions/metrics-store-add-total.js
+++ b/ucan-invocation/functions/metrics-store-add-total.js
@@ -2,7 +2,8 @@ import * as Sentry from '@sentry/serverless'
 
 import { createMetricsTable } from '../tables/metrics.js'
 import { parseKinesisEvent } from '../utils/parse-kinesis-event.js'
-import { STORE_ADD, STREAM_TYPE } from '../constants.js'
+import { hasOkReceipt } from '../utils/receipt.js'
+import { STORE_ADD } from '../constants.js'
 
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
@@ -37,7 +38,7 @@ async function handler(event) {
  */
 export async function updateStoreAddTotal (ucanInvocations, ctx) {
   const invocationsWithStoreAdd = ucanInvocations.filter(
-    inv => inv.value.att.find(a => a.can === STORE_ADD) && inv.type === STREAM_TYPE.RECEIPT
+    inv => inv.value.att.find(a => a.can === STORE_ADD) && hasOkReceipt(inv)
   ).flatMap(inv => inv.value.att)
 
   await ctx.metricsTable.incrementStoreAddTotal(invocationsWithStoreAdd)

--- a/ucan-invocation/functions/metrics-store-remove-size-total.js
+++ b/ucan-invocation/functions/metrics-store-remove-size-total.js
@@ -2,8 +2,9 @@ import * as Sentry from '@sentry/serverless'
 
 import { createCarStore } from '../buckets/car-store.js'
 import { createMetricsTable } from '../tables/metrics.js'
+import { hasOkReceipt } from '../utils/receipt.js'
 import { parseKinesisEvent } from '../utils/parse-kinesis-event.js'
-import { STORE_REMOVE, STREAM_TYPE } from '../constants.js'
+import { STORE_REMOVE } from '../constants.js'
 
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
@@ -36,7 +37,7 @@ async function handler(event) {
  */
 export async function updateRemoveSizeTotal (ucanInvocations, ctx) {
   const invocationsWithStoreRemove = ucanInvocations.filter(
-    inv => inv.value.att.find(a => a.can === STORE_REMOVE) && inv.type === STREAM_TYPE.RECEIPT
+    inv => inv.value.att.find(a => a.can === STORE_REMOVE) && hasOkReceipt(inv)
   ).flatMap(inv => inv.value.att)
 
   // TODO: once we have receipts for store/remove, replace this

--- a/ucan-invocation/functions/metrics-store-remove-total.js
+++ b/ucan-invocation/functions/metrics-store-remove-total.js
@@ -1,8 +1,9 @@
 import * as Sentry from '@sentry/serverless'
 
 import { createMetricsTable } from '../tables/metrics.js'
+import { hasOkReceipt } from '../utils/receipt.js'
 import { parseKinesisEvent } from '../utils/parse-kinesis-event.js'
-import { STORE_REMOVE, STREAM_TYPE } from '../constants.js'
+import { STORE_REMOVE } from '../constants.js'
 
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
@@ -37,7 +38,7 @@ async function handler(event) {
  */
 export async function updateStoreRemoveTotal (ucanInvocations, ctx) {
   const invocationsWithStoreRemove = ucanInvocations.filter(
-    inv => inv.value.att.find(a => a.can === STORE_REMOVE) && inv.type === STREAM_TYPE.RECEIPT
+    inv => inv.value.att.find(a => a.can === STORE_REMOVE) && hasOkReceipt(inv)
   ).flatMap(inv => inv.value.att)
 
   await ctx.metricsTable.incrementStoreRemoveTotal(invocationsWithStoreRemove)

--- a/ucan-invocation/functions/metrics-upload-add-total.js
+++ b/ucan-invocation/functions/metrics-upload-add-total.js
@@ -1,8 +1,9 @@
 import * as Sentry from '@sentry/serverless'
 
 import { createMetricsTable } from '../tables/metrics.js'
+import { hasOkReceipt } from '../utils/receipt.js'
 import { parseKinesisEvent } from '../utils/parse-kinesis-event.js'
-import { UPLOAD_ADD, STREAM_TYPE } from '../constants.js'
+import { UPLOAD_ADD } from '../constants.js'
 
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
@@ -37,7 +38,7 @@ async function handler(event) {
  */
 export async function updateUploadAddTotal (ucanInvocations, ctx) {
   const invocationsWithUploadAdd = ucanInvocations.filter(
-    inv => inv.value.att.find(a => a.can === UPLOAD_ADD) && inv.type === STREAM_TYPE.RECEIPT
+    inv => inv.value.att.find(a => a.can === UPLOAD_ADD) && hasOkReceipt(inv)
   ).flatMap(inv => inv.value.att)
 
   await ctx.metricsTable.incrementUploadAddTotal(invocationsWithUploadAdd)

--- a/ucan-invocation/functions/metrics-upload-remove-total.js
+++ b/ucan-invocation/functions/metrics-upload-remove-total.js
@@ -1,8 +1,9 @@
 import * as Sentry from '@sentry/serverless'
 
 import { createMetricsTable } from '../tables/metrics.js'
+import { hasOkReceipt } from '../utils/receipt.js'
 import { parseKinesisEvent } from '../utils/parse-kinesis-event.js'
-import { UPLOAD_REMOVE, STREAM_TYPE } from '../constants.js'
+import { UPLOAD_REMOVE } from '../constants.js'
 
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
@@ -37,7 +38,7 @@ async function handler(event) {
  */
 export async function updateUploadRemoveTotal (ucanInvocations, ctx) {
   const invocationsWithUploadRemove = ucanInvocations.filter(
-    inv => inv.value.att.find(a => a.can === UPLOAD_REMOVE) && inv.type === STREAM_TYPE.RECEIPT
+    inv => inv.value.att.find(a => a.can === UPLOAD_REMOVE) && hasOkReceipt(inv)
   ).flatMap(inv => inv.value.att)
 
   await ctx.metricsTable.incrementUploadRemoveTotal(invocationsWithUploadRemove)

--- a/ucan-invocation/functions/space-metrics-store-add-size-total.js
+++ b/ucan-invocation/functions/space-metrics-store-add-size-total.js
@@ -2,8 +2,9 @@ import * as Sentry from '@sentry/serverless'
 
 import { createCarStore } from '../buckets/car-store.js'
 import { createSpaceMetricsTable } from '../tables/space-metrics.js'
+import { hasOkReceipt } from '../utils/receipt.js'
 import { parseKinesisEvent } from '../utils/parse-kinesis-event.js'
-import { STORE_ADD, STREAM_TYPE } from '../constants.js'
+import { STORE_ADD } from '../constants.js'
 
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
@@ -36,7 +37,7 @@ async function handler(event) {
  */
 export async function updateAddSizeTotal (ucanInvocations, ctx) {
   const invocationsWithStoreAdd = ucanInvocations.filter(
-    inv => inv.value.att.find(a => a.can === STORE_ADD) && inv.type === STREAM_TYPE.RECEIPT
+    inv => inv.value.att.find(a => a.can === STORE_ADD) && hasOkReceipt(inv)
   ).flatMap(inv => inv.value.att)
 
   await ctx.spaceMetricsTable.incrementStoreAddSizeTotal(invocationsWithStoreAdd)

--- a/ucan-invocation/functions/space-metrics-store-add-total.js
+++ b/ucan-invocation/functions/space-metrics-store-add-total.js
@@ -1,8 +1,9 @@
 import * as Sentry from '@sentry/serverless'
 
 import { createSpaceMetricsTable } from '../tables/space-metrics.js'
+import { hasOkReceipt } from '../utils/receipt.js'
 import { parseKinesisEvent } from '../utils/parse-kinesis-event.js'
-import { STORE_ADD, STREAM_TYPE } from '../constants.js'
+import { STORE_ADD } from '../constants.js'
 
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
@@ -43,7 +44,7 @@ async function handler(event) {
  */
 export async function updateStoreCount (ucanInvocations, ctx) {
   const invocationsWithStoreAdd = ucanInvocations.filter(
-    inv => inv.value.att.find(a => a.can === STORE_ADD) && inv.type === STREAM_TYPE.RECEIPT
+    inv => inv.value.att.find(a => a.can === STORE_ADD) && hasOkReceipt(inv)
   ).flatMap(inv => inv.value.att)
 
   await ctx.spaceMetricsTable.incrementStoreAddCount(invocationsWithStoreAdd)

--- a/ucan-invocation/functions/space-metrics-store-remove-size-total.js
+++ b/ucan-invocation/functions/space-metrics-store-remove-size-total.js
@@ -2,8 +2,9 @@ import * as Sentry from '@sentry/serverless'
 
 import { createCarStore } from '../buckets/car-store.js'
 import { createSpaceMetricsTable } from '../tables/space-metrics.js'
+import { hasOkReceipt } from '../utils/receipt.js'
 import { parseKinesisEvent } from '../utils/parse-kinesis-event.js'
-import { STORE_REMOVE, STREAM_TYPE } from '../constants.js'
+import { STORE_REMOVE } from '../constants.js'
 
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
@@ -36,7 +37,7 @@ async function handler(event) {
  */
 export async function updateRemoveSizeTotal (ucanInvocations, ctx) {
   const invocationsWithStoreRemove = ucanInvocations.filter(
-    inv => inv.value.att.find(a => a.can === STORE_REMOVE) && inv.type === STREAM_TYPE.RECEIPT
+    inv => inv.value.att.find(a => a.can === STORE_REMOVE) && hasOkReceipt(inv)
   ).flatMap(inv => inv.value.att)
 
   // TODO: once we have receipts for store/remove, replace this

--- a/ucan-invocation/functions/space-metrics-store-remove-total.js
+++ b/ucan-invocation/functions/space-metrics-store-remove-total.js
@@ -1,8 +1,9 @@
 import * as Sentry from '@sentry/serverless'
 
 import { createSpaceMetricsTable } from '../tables/space-metrics.js'
+import { hasOkReceipt } from '../utils/receipt.js'
 import { parseKinesisEvent } from '../utils/parse-kinesis-event.js'
-import { STORE_REMOVE, STREAM_TYPE } from '../constants.js'
+import { STORE_REMOVE } from '../constants.js'
 
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
@@ -43,7 +44,7 @@ async function handler(event) {
  */
 export async function updateStoreCount (ucanInvocations, ctx) {
   const invocationsWithStoreRemove = ucanInvocations.filter(
-    inv => inv.value.att.find(a => a.can === STORE_REMOVE) && inv.type === STREAM_TYPE.RECEIPT
+    inv => inv.value.att.find(a => a.can === STORE_REMOVE) && hasOkReceipt(inv)
   ).flatMap(inv => inv.value.att)
 
   await ctx.spaceMetricsTable.incrementStoreRemoveCount(invocationsWithStoreRemove)

--- a/ucan-invocation/functions/space-metrics-upload-add-total.js
+++ b/ucan-invocation/functions/space-metrics-upload-add-total.js
@@ -1,8 +1,9 @@
 import * as Sentry from '@sentry/serverless'
 
 import { createSpaceMetricsTable } from '../tables/space-metrics.js'
+import { hasOkReceipt } from '../utils/receipt.js'
 import { parseKinesisEvent } from '../utils/parse-kinesis-event.js'
-import { UPLOAD_ADD, STREAM_TYPE } from '../constants.js'
+import { UPLOAD_ADD } from '../constants.js'
 
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
@@ -43,7 +44,7 @@ async function handler(event) {
  */
 export async function updateUploadCount (ucanInvocations, ctx) {
   const invocationsWithUploadAdd = ucanInvocations.filter(
-    inv => inv.value.att.find(a => a.can === UPLOAD_ADD) && inv.type === STREAM_TYPE.RECEIPT
+    inv => inv.value.att.find(a => a.can === UPLOAD_ADD) && hasOkReceipt(inv)
   ).flatMap(inv => inv.value.att)
 
   await ctx.spaceMetricsTable.incrementUploadAddCount(invocationsWithUploadAdd)

--- a/ucan-invocation/functions/space-metrics-upload-remove-total.js
+++ b/ucan-invocation/functions/space-metrics-upload-remove-total.js
@@ -1,8 +1,9 @@
 import * as Sentry from '@sentry/serverless'
 
 import { createSpaceMetricsTable } from '../tables/space-metrics.js'
+import { hasOkReceipt } from '../utils/receipt.js'
 import { parseKinesisEvent } from '../utils/parse-kinesis-event.js'
-import { UPLOAD_REMOVE, STREAM_TYPE } from '../constants.js'
+import { UPLOAD_REMOVE } from '../constants.js'
 
 Sentry.AWSLambda.init({
   environment: process.env.SST_STAGE,
@@ -37,7 +38,7 @@ async function handler(event) {
  */
 export async function updateUploadCount (ucanInvocations, ctx) {
   const invocationsWithUploadRemove = ucanInvocations.filter(
-    inv => inv.value.att.find(a => a.can === UPLOAD_REMOVE) && inv.type === STREAM_TYPE.RECEIPT
+    inv => inv.value.att.find(a => a.can === UPLOAD_REMOVE) && hasOkReceipt(inv)
   ).flatMap(inv => inv.value.att)
 
   await ctx.spaceMetricsTable.incrementUploadRemoveCount(invocationsWithUploadRemove)

--- a/ucan-invocation/test/functions/metrics-store-add-total.test.js
+++ b/ucan-invocation/test/functions/metrics-store-add-total.test.js
@@ -53,6 +53,9 @@ test('handles a batch of single invocation with store/add', async t => {
         iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }]
 
@@ -97,6 +100,9 @@ test('handles batch of single invocations with multiple store/add attributes', a
       iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }]
 
@@ -140,6 +146,9 @@ test('handles a batch of single invocation without store/add', async t => {
         iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }]
 

--- a/ucan-invocation/test/functions/metrics-store-remove-size-total.test.js
+++ b/ucan-invocation/test/functions/metrics-store-remove-size-total.test.js
@@ -72,6 +72,9 @@ test('handles a batch of single invocation with store/remove', async t => {
         iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }]
 
@@ -128,6 +131,9 @@ test('handles batch of single invocations with multiple store/remove attributes'
       iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }]
 
@@ -184,6 +190,9 @@ test('handles a batch of single invocation without store/remove', async t => {
         iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }]
 

--- a/ucan-invocation/test/functions/metrics-store-remove-total.test.js
+++ b/ucan-invocation/test/functions/metrics-store-remove-total.test.js
@@ -52,6 +52,9 @@ test('handles a batch of single invocation with store/remove', async t => {
         iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }]
 
@@ -95,6 +98,9 @@ test('handles batch of single invocations with multiple store/remove attributes'
       iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }]
 
@@ -139,6 +145,9 @@ test('handles a batch of single invocation without store/remove', async t => {
         iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }]
 

--- a/ucan-invocation/test/functions/metrics-upload-add-total.test.js
+++ b/ucan-invocation/test/functions/metrics-upload-add-total.test.js
@@ -53,6 +53,9 @@ test('handles a batch of single invocation with upload/add', async t => {
         iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }]
 
@@ -97,6 +100,9 @@ test('handles batch of single invocations with multiple upload/add attributes', 
       iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }]
 
@@ -140,6 +146,9 @@ test('handles a batch of single invocation without upload/add', async t => {
         iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }]
 

--- a/ucan-invocation/test/functions/metrics-upload-remove-total.test.js
+++ b/ucan-invocation/test/functions/metrics-upload-remove-total.test.js
@@ -52,6 +52,9 @@ test('handles a batch of single invocation with upload/remove', async t => {
         iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }]
 
@@ -95,6 +98,9 @@ test('handles batch of single invocations with multiple upload/remove attributes
       iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }]
 
@@ -139,6 +145,9 @@ test('handles a batch of single invocation without upload/remove', async t => {
         iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }]
 

--- a/ucan-invocation/test/functions/space-metrics-store-add-size-total.test.js
+++ b/ucan-invocation/test/functions/space-metrics-store-add-size-total.test.js
@@ -75,6 +75,9 @@ test('handles a batch of single invocation with store/add', async t => {
       iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }]
 
@@ -133,6 +136,9 @@ test('handles batch of single invocation with multiple store/add attributes', as
       iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }]
 
@@ -193,6 +199,9 @@ test('handles batch of multiple invocations with store/add in same space', async
       iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }))
 
@@ -251,6 +260,9 @@ test('handles batch of multiple invocations with store/add in multiple spaces', 
       iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }))
 
@@ -315,6 +327,9 @@ test('errors handling batch of multiple invocations with more transactions than 
       iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }))
 

--- a/ucan-invocation/test/functions/space-metrics-store-add-total.test.js
+++ b/ucan-invocation/test/functions/space-metrics-store-add-total.test.js
@@ -53,6 +53,9 @@ test('handles a batch of single invocation with store/add', async t => {
       iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }]
 
@@ -98,6 +101,9 @@ test('handles batch of single invocation with multiple store/add attributes', as
       iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }]
 
@@ -145,6 +151,9 @@ test('handles batch of multiple invocations with store/add in same space', async
       iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }))
 
@@ -191,6 +200,9 @@ test('handles batch of multiple invocations with store/add in multiple spaces', 
       iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }))
 
@@ -243,6 +255,9 @@ test('errors handling batch of multiple invocations with more transactions than 
       iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }))
 

--- a/ucan-invocation/test/functions/space-metrics-store-remove-size-total.test.js
+++ b/ucan-invocation/test/functions/space-metrics-store-remove-size-total.test.js
@@ -73,6 +73,9 @@ test('handles a batch of single invocation with store/remove', async t => {
       iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }]
 
@@ -130,6 +133,9 @@ test('handles batch of single invocation with multiple store/remove attributes',
       iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }]
 
@@ -189,6 +195,9 @@ test('handles batch of multiple invocations with store/remove in same space', as
       iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }))
 
@@ -246,6 +255,9 @@ test('handles batch of multiple invocations with store/remove in multiple spaces
       iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }))
 
@@ -309,6 +321,9 @@ test('errors handling batch of multiple invocations with more transactions than 
         iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }))
 

--- a/ucan-invocation/test/functions/space-metrics-store-remove-total.test.js
+++ b/ucan-invocation/test/functions/space-metrics-store-remove-total.test.js
@@ -52,6 +52,9 @@ test('handles a batch of single invocation with store/remove', async t => {
       iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }]
 
@@ -96,6 +99,9 @@ test('handles batch of single invocation with multiple store/remove attributes',
       iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }]
 
@@ -142,6 +148,9 @@ test('handles batch of multiple invocations with store/remove in same space', as
       iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }))
 
@@ -187,6 +196,9 @@ test('handles batch of multiple invocations with store/remove in multiple spaces
       iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }))
 
@@ -238,6 +250,9 @@ test('errors handling batch of multiple invocations with more transactions than 
         iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }))
 

--- a/ucan-invocation/test/functions/space-metrics-upload-add-total.test.js
+++ b/ucan-invocation/test/functions/space-metrics-upload-add-total.test.js
@@ -53,6 +53,9 @@ test('handles a batch of single invocation with upload/add', async t => {
         iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }]
 
@@ -98,6 +101,9 @@ test('handles batch of single invocation with multiple upload/add attributes', a
       iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }]
 
@@ -145,6 +151,9 @@ test('handles batch of multiple invocations with upload/add in same space', asyn
         iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }))
 
@@ -191,6 +200,9 @@ test('handles batch of multiple invocations with upload/add in multiple spaces',
         iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }))
 
@@ -242,6 +254,9 @@ test('errors handling batch of multiple invocations with more transactions than 
         iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }))
 

--- a/ucan-invocation/test/functions/space-metrics-upload-remove-total.test.js
+++ b/ucan-invocation/test/functions/space-metrics-upload-remove-total.test.js
@@ -52,6 +52,9 @@ test('handles a batch of single invocation with upload/remove', async t => {
         iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }]
 
@@ -96,6 +99,9 @@ test('handles batch of single invocation with multiple upload/remove attributes'
       iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }]
 
@@ -142,6 +148,9 @@ test('handles batch of multiple invocations with upload/remove in same space', a
         iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }))
 
@@ -187,6 +196,9 @@ test('handles batch of multiple invocations with upload/remove in multiple space
         iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }))
 
@@ -237,6 +249,9 @@ test('errors handling batch of multiple invocations with more transactions than 
         iss: alice.did()
     },
     type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
     ts: Date.now()
   }))
 

--- a/ucan-invocation/types.ts
+++ b/ucan-invocation/types.ts
@@ -51,6 +51,7 @@ export interface UcanInvocation {
   value: UcanInvocationValue
   ts: number
   type: UcanInvocationType
+  out?: ReceiptResult
 }
 
 export interface UcanInvocationValue {
@@ -63,3 +64,19 @@ export interface UcanInvocationValue {
 export interface LinkJSON<T extends UnknownLink = UnknownLink> {
   '/': ToString<T>
 }
+
+/**
+ * Defines result type as per invocation spec
+ *
+ * @see https://github.com/ucan-wg/invocation/#6-result
+ */
+export type ReceiptResult<T = unknown, X extends {} = {}> = Variant<{
+  ok: T
+  error: X
+}>
+
+export type Variant<U extends Record<string, unknown>> = {
+  [Key in keyof U]: { [K in Exclude<keyof U, Key>]?: never } & {
+    [K in Key]: U[Key]
+  }
+}[keyof U]

--- a/ucan-invocation/utils/receipt.js
+++ b/ucan-invocation/utils/receipt.js
@@ -1,0 +1,9 @@
+import { STREAM_TYPE } from '../constants.js'
+
+/**
+ * 
+ * @param {import('../types').UcanInvocation} ucanInvocation 
+ */
+export function hasOkReceipt (ucanInvocation) {
+  return ucanInvocation.type === STREAM_TYPE.RECEIPT && Boolean(ucanInvocation.out?.ok)
+}

--- a/upload-api/test/ucan-invocation.test.js
+++ b/upload-api/test/ucan-invocation.test.js
@@ -503,6 +503,7 @@ test('can process ucan log request for given receipt after its invocation stored
         t.is(data.carCid, invocationCid.toString())
         t.is(data.invocationCid, receiptBlock.cid.toString())
         t.is(data.type, STREAM_TYPE.RECEIPT)
+        t.deepEqual(data.out, out)
         t.deepEqual(data.value, kinesisWorkflowInvocations[0].value)
         return Promise.resolve()
       }

--- a/upload-api/ucan-invocation.js
+++ b/upload-api/ucan-invocation.js
@@ -121,7 +121,8 @@ export async function processInvocationReceipt (bytes, ctx) {
         invocationCid: receiptBlock.cid.toString(),
         value: invocation,
         ts: Date.now(),
-        type: STREAM_TYPE.RECEIPT
+        type: STREAM_TYPE.RECEIPT,
+        out: receiptBlock.data.out
       })
     ),
     // https://docs.aws.amazon.com/streams/latest/dev/key-concepts.html


### PR DESCRIPTION
We need to know in UCAN Stream if receipt is from a success invocation or not. Therefore passing `out` from receipt in and validate in consumers