### PR TITLE
feat: implement DelegationsStorage on top of DynamoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Next, ensure the `AWS_REGION`, `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` e
 not need to be set to real values - the following works in `bash`-like shells:
 
 ```
-export AWS_REGION='us-west-2'; export AWS_ACCESS_KEY_ID='NOSUCH'; export AWS_SECRET_ACCESS_KEY='NOSUCH
+export AWS_REGION='us-west-2'; export AWS_ACCESS_KEY_ID='NOSUCH'; export AWS_SECRET_ACCESS_KEY='NOSUCH'
 ```
 
 Finally, to run the tests for all packages, run:

--- a/upload-api/access-types.ts
+++ b/upload-api/access-types.ts
@@ -1,0 +1,29 @@
+import * as Ucanto from '@ucanto/interface'
+
+interface ByAudience {
+  audience: Ucanto.DID<'key' | 'mailto'>
+}
+export type Query = ByAudience
+
+export interface DelegationsStorage<
+  Cap extends Ucanto.Capability = Ucanto.Capability
+> {
+  /**
+   * write several items into storage
+   *
+   * @param delegations - delegations to store
+   */
+  putMany: (
+    ...delegations: Array<Ucanto.Delegation<Ucanto.Tuple<Cap>>>
+  ) => Promise<unknown>
+
+  /**
+   * get number of stored items
+   */
+  count: () => Promise<bigint>
+
+  /**
+   * find all items that match the query
+   */
+  find: (query: Query) => AsyncIterable<Ucanto.Delegation<Ucanto.Tuple<Cap>>>
+}

--- a/upload-api/buckets/delegations-store.js
+++ b/upload-api/buckets/delegations-store.js
@@ -1,0 +1,77 @@
+import {
+  S3Client,
+  PutObjectCommand,
+  GetObjectCommand,
+} from '@aws-sdk/client-s3'
+import pRetry from 'p-retry'
+import { CID } from 'multiformats/cid'
+import { base32 } from 'multiformats/bases/base32'
+
+/**
+ * Abstraction layer with Factory to perform operations on bucket.
+ *
+ * @param {string} region
+ * @param {string} bucketName
+ * @param {import('@aws-sdk/client-s3').ServiceInputTypes} [options]
+ */
+export function createDelegationsStore(region, bucketName, options = {}) {
+  const s3client = new S3Client({
+    region,
+    ...options,
+  })
+  return useDelegationsStore(s3client, bucketName)
+}
+
+/**
+ * TODO: this should use the function in w3up access-api/src/models/delegations.js
+ * 
+ * @param { CID} cid
+ */
+function createDelegationsBucketKey (cid) {
+  const key = /** @type {const} */ (
+    `/delegations/${cid.toString(base32)}.car`
+  )
+  return key
+}
+
+/**
+ * @param {S3Client} s3client
+ * @param {string} bucketName
+ * @returns {import('../types').DelegationsBucket}
+ */
+export const useDelegationsStore = (s3client, bucketName) => {
+  return {
+    /**
+     * Put Delegation into bucket.
+     *
+     * @param {CID} cid
+     * @param {Uint8Array} bytes
+     */
+    put: async (cid, bytes) => {
+      const putCmd = new PutObjectCommand({
+        Bucket: bucketName,
+        Key: createDelegationsBucketKey(cid),
+        Body: bytes,
+      })
+      await pRetry(() => s3client.send(putCmd))
+    },
+    /**
+     * Get CAR bytes for a given delegation.
+     *
+     * @param {CID} cid 
+     */
+    get: async (cid) => {
+      const getObjectCmd = new GetObjectCommand({
+        Bucket: bucketName,
+        Key: createDelegationsBucketKey(cid),
+      })
+      const s3Object = await s3client.send(getObjectCmd)
+      const bytes = await s3Object.Body?.transformToByteArray()
+      if (!bytes) {
+        return
+      }
+
+      return bytes
+    }
+  }
+}

--- a/upload-api/buckets/delegations-store.js
+++ b/upload-api/buckets/delegations-store.js
@@ -4,8 +4,9 @@ import {
   GetObjectCommand,
 } from '@aws-sdk/client-s3'
 import pRetry from 'p-retry'
-import { CID } from 'multiformats/cid'
 import { base32 } from 'multiformats/bases/base32'
+
+/** @typedef {import('multiformats/cid').CID} CID */
 
 /**
  * Abstraction layer with Factory to perform operations on bucket.

--- a/upload-api/tables/delegations.js
+++ b/upload-api/tables/delegations.js
@@ -1,19 +1,13 @@
-import * as Ucanto from '@ucanto/interface'
 import { base32 } from 'multiformats/bases/base32'
 import {
   DynamoDBClient,
-  GetItemCommand,
-  PutItemCommand,
-  DeleteItemCommand,
   QueryCommand,
   BatchWriteItemCommand,
   DescribeTableCommand,
 } from '@aws-sdk/client-dynamodb'
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
-import { S3Client } from '@aws-sdk/client-s3'
 
 import { CID } from 'multiformats/cid'
-import * as Link from 'multiformats/link'
 import {
   bytesToDelegations,
   delegationsToBytes
@@ -96,7 +90,7 @@ export function useDelegationsTable (dynamoDb, tableName, bucket) {
 /**
  * TODO: fix the return type to use CID and DID string types
  * 
- * @param {Ucanto.Delegation} d
+ * @param {import('@ucanto/interface').Delegation} d
  * @returns {{cid: string, audience: string, issuer: string}}}
  */
 function createDelegationItem (d) {
@@ -107,27 +101,11 @@ function createDelegationItem (d) {
   }
 }
 
-/**
- * TODO: fix the return type to use CID and DID string types
- * 
- * @param {string} tableName
- * @param {Ucanto.Delegation} d
- * @returns {PutItemCommand}
- */
-function createDelegationPutItemCommand (tableName, d) {
-  return new PutItemCommand({
-    TableName: tableName,
-    Item: marshall(
-      createDelegationItem(d),
-      { removeUndefinedValues: true }),
-  })
-}
-
 /** 
-  * @param {import('../types').DelegationsBucket} bucket
-  * @param {CID} cid
-  * @returns {Promise<Ucanto.Delegation>}
-  */
+ * @param {import('../types').DelegationsBucket} bucket
+ * @param {CID} cid
+ * @returns {Promise<import('@ucanto/interface').Delegation>}
+ */
 async function cidToDelegation (bucket, cid) {
   const delegationCarBytes = await bucket.get(cid)
   if (!delegationCarBytes) {
@@ -145,7 +123,7 @@ async function cidToDelegation (bucket, cid) {
  * TODO: can we use the function in w3up access-api/src/models/delegations.js?
  * 
  * @param {import('../types').DelegationsBucket} bucket
- * @param {Iterable<Ucanto.Delegation>} delegations
+ * @param {Iterable<import('@ucanto/interface').Delegation>} delegations
  */
 async function writeDelegations (bucket, delegations) {
   return writeEntries(
@@ -160,6 +138,7 @@ async function writeDelegations (bucket, delegations) {
 
 /**
  * TODO: can we use the function in w3up access-api/src/models/delegations.js?
+ * 
  * @param {import('../types').DelegationsBucket} bucket
  * @param {Iterable<readonly [key: CID, value: Uint8Array ]>} entries
  */

--- a/upload-api/tables/delegations.js
+++ b/upload-api/tables/delegations.js
@@ -1,0 +1,168 @@
+import * as Ucanto from '@ucanto/interface'
+import { base32 } from 'multiformats/bases/base32'
+import {
+  DynamoDBClient,
+  GetItemCommand,
+  PutItemCommand,
+  DeleteItemCommand,
+  QueryCommand,
+  BatchWriteItemCommand,
+  DescribeTableCommand,
+} from '@aws-sdk/client-dynamodb'
+import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
+import { S3Client } from '@aws-sdk/client-s3'
+
+import { CID } from 'multiformats/cid'
+import * as Link from 'multiformats/link'
+import {
+  bytesToDelegations,
+  delegationsToBytes
+} from '@web3-storage/access/encoding'
+
+/**
+ * Abstraction layer to handle operations on Store Table.
+ *
+ * @param {string} region
+ * @param {string} tableName
+ * @param {import('../types').DelegationsBucket} bucket
+ * @param {object} [options]
+ * @param {string} [options.endpoint]
+ */
+export function createDelegationsTable (region, tableName, bucket, options = {}) {
+  const dynamoDb = new DynamoDBClient({
+    region,
+    endpoint: options.endpoint,
+  })
+
+  return useDelegationsTable(dynamoDb, tableName, bucket)
+}
+
+/**
+ * @param {DynamoDBClient} dynamoDb
+ * @param {string} tableName
+ * @param {import('../types').DelegationsBucket} bucket
+ * @returns {import('../access-types').DelegationsStorage}
+ */
+export function useDelegationsTable (dynamoDb, tableName, bucket) {
+  return {
+    putMany: async (...delegations) => {
+      if (delegations.length === 0) {
+        return
+      }
+      await writeDelegations(bucket, delegations)
+      // TODO: we should look at the return value of this BatchWriteItemCommand and either retry or clean up delegations that we fail to index
+      await dynamoDb.send(new BatchWriteItemCommand({
+        RequestItems: {
+          [tableName]: delegations.map(d => ({
+            PutRequest: {
+              Item: marshall(
+                createDelegationItem(d),
+                { removeUndefinedValues: true })
+            }
+          })
+          )
+        }
+      }))
+    },
+    count: async () => {
+      const result = await dynamoDb.send(new DescribeTableCommand({
+        TableName: tableName
+      }))
+
+      return BigInt(result.Table?.ItemCount ?? -1)
+    },
+    find: async function* find (query) {
+      const cmd = new QueryCommand({
+        TableName: tableName,
+        // Limit: options.size || 20, // TODO should we introduce a limit here?
+        KeyConditions: {
+          audience: {
+            ComparisonOperator: 'EQ',
+            AttributeValueList: [{ S: query.audience }]
+          }
+        },
+        AttributesToGet: ['cid']
+      })
+      const response = await dynamoDb.send(cmd)
+
+      for (const result of response.Items ?? []) {
+        const { cid } = unmarshall(result)
+        yield cidToDelegation(bucket, CID.parse(cid))
+      }
+    }
+  }
+}
+
+/**
+ * TODO: fix the return type to use CID and DID string types
+ * 
+ * @param {Ucanto.Delegation} d
+ * @returns {{cid: string, audience: string, issuer: string}}}
+ */
+function createDelegationItem (d) {
+  return {
+    cid: d.cid.toString(),
+    audience: d.audience.did(),
+    issuer: d.issuer.did(),
+  }
+}
+
+/**
+ * TODO: fix the return type to use CID and DID string types
+ * 
+ * @param {string} tableName
+ * @param {Ucanto.Delegation} d
+ * @returns {PutItemCommand}
+ */
+function createDelegationPutItemCommand (tableName, d) {
+  return new PutItemCommand({
+    TableName: tableName,
+    Item: marshall(
+      createDelegationItem(d),
+      { removeUndefinedValues: true }),
+  })
+}
+
+/** 
+  * @param {import('../types').DelegationsBucket} bucket
+  * @param {CID} cid
+  * @returns {Promise<Ucanto.Delegation>}
+  */
+async function cidToDelegation (bucket, cid) {
+  const delegationCarBytes = await bucket.get(cid)
+  if (!delegationCarBytes) {
+    throw new Error(`failed to read car bytes for cid ${cid.toString(base32)}`)
+  }
+  const delegations = bytesToDelegations(delegationCarBytes)
+  const delegation = delegations.find((d) => d.cid.equals(cid))
+  if (!delegation) {
+    throw new Error(`failed to parse delegation with expected cid ${cid.toString(base32)}`)
+  }
+  return delegation
+}
+
+/**
+ * TODO: can we use the function in w3up access-api/src/models/delegations.js?
+ * 
+ * @param {import('../types').DelegationsBucket} bucket
+ * @param {Iterable<Ucanto.Delegation>} delegations
+ */
+async function writeDelegations (bucket, delegations) {
+  return writeEntries(
+    bucket,
+    [...delegations].map((delegation) => {
+      const carBytes = delegationsToBytes([delegation])
+      const value = carBytes
+      return /** @type {[key: CID, value: Uint8Array]} */ ([delegation.cid, value])
+    })
+  )
+}
+
+/**
+ * TODO: can we use the function in w3up access-api/src/models/delegations.js?
+ * @param {import('../types').DelegationsBucket} bucket
+ * @param {Iterable<readonly [key: CID, value: Uint8Array ]>} entries
+ */
+async function writeEntries (bucket, entries) {
+  await Promise.all([...entries].map(([key, value]) => bucket.put(key, value)))
+}

--- a/upload-api/tables/index.js
+++ b/upload-api/tables/index.js
@@ -26,3 +26,33 @@ export const uploadTableProps = {
   // space + root must be unique to satisfy index constraint
   primaryIndex: { partitionKey: 'space', sortKey: 'root' },
 }
+
+/** @type TableProps */
+export const delegationsTableProps = {
+  fields: {
+    cid: 'string',        // `baf...x`
+    audience: 'string',   // `did:web:service`
+    issuer: 'string',     // `did:key:agent`
+    expiration: 'string', // `9256939505` (unix timestamp)
+    insertedAt: 'string', // `2022-12-24T...`
+    updatedAt: 'string',  // `2022-12-24T...`
+  },
+  // TODO does this index setup seem right?
+  // we want to query by audience, but that won't necessarily be unique, so use cid as sortKey
+  primaryIndex: { partitionKey: 'audience', sortKey: 'cid' },
+}
+
+/** @type TableProps */
+export const provisionsTableProps = {
+  fields: {
+    cid: 'string',        // `baf...x` (CID of invocation that created this provision)
+    consumer: 'string',   // `did:key:space` (DID of the actor that is consuming the provider, e.g. a space DID)
+    provider: 'string',   // `did:web:service` (DID of the provider, e.g. a storage provider)
+    sponsor: 'string',    // `did:key:agent` (DID of the actor that authorized this provision)
+    insertedAt: 'string', // `2022-12-24T...`
+    updatedAt: 'string',  // `2022-12-24T...`
+  },
+  // TODO do we need a sort key? cid should be sufficiently random to meet the criteria in https://aws.amazon.com/blogs/database/choosing-the-right-dynamodb-partition-key/ so maybe not?
+  // TODO also are we sure that a single invocation will only create a single provision? the D1 schema used CID as a PRIMARY KEY so I think this should be fine, but will it always be true?
+  primaryIndex: { partitionKey: 'cid' },
+}

--- a/upload-api/test/service/delegations.test.js
+++ b/upload-api/test/service/delegations.test.js
@@ -1,0 +1,153 @@
+/* eslint-disable no-loop-func */
+import { test } from '../helpers/context.js'
+import * as principal from '@ucanto/principal'
+import * as Ucanto from '@ucanto/interface'
+import * as ucanto from '@ucanto/core'
+import * as assert from 'node:assert'
+import { collect } from 'streaming-iterables'
+import {
+  createS3,
+  createBucket,
+  createDynamodDb,
+  createTable,
+} from '../helpers/resources.js'
+import { delegationsTableProps } from '../../tables/index.js'
+import { useDelegationsTable } from '../../tables/delegations.js'
+import { useDelegationsStore } from '../../buckets/delegations-store.js'
+
+/**
+ * 
+ * TODO: migrate back to function originally defined in w3up access-api/src/utils/ucan.js
+ * 
+ * @param {object} options
+ * @param {PromiseLike<principal.ed25519.EdSigner>} [options.audience]
+ * @param {PromiseLike<principal.ed25519.EdSigner>} [options.issuer]
+ * @param {Ucanto.URI} [options.with]
+ * @param {Ucanto.Ability} [options.can]
+ */
+export async function createSampleDelegation(options = {}) {
+  const {
+    issuer = Promise.resolve(principal.ed25519.generate()),
+    audience = Promise.resolve(principal.ed25519.generate()),
+    can,
+  } = options
+  const delegation = await ucanto.delegate({
+    issuer: await issuer,
+    audience: await audience,
+    capabilities: [
+      {
+        with: options.with || 'urn:',
+        can: can || 'test/*',
+      },
+    ],
+  })
+  return delegation
+}
+
+/**
+ * 
+ *  * TODO: migrate back to function originally defined in w3up access-api/test/delegations-storage.testjs
+
+ * @param {object} [opts]
+ * @param {Ucanto.Signer<Ucanto.DID>} [opts.issuer]
+ * @param {Ucanto.Principal} [opts.audience]
+ * @param {Ucanto.Capabilities} [opts.capabilities]
+ * @returns {Promise<Ucanto.Delegation>}
+ */
+async function createDelegation(opts = {}) {
+  const {
+    issuer = await principal.ed25519.generate(),
+    audience = issuer,
+    capabilities = [
+      {
+        can: 'test/*',
+        with: issuer.did(),
+      },
+    ],
+  } = opts
+  return await ucanto.delegate({
+    issuer,
+    audience,
+    capabilities,
+  })
+}
+
+test.before(async (t) => {
+  Object.assign(t.context, {
+    dynamo: await createDynamodDb(),
+    s3: (await createS3()).client,
+  })
+})
+
+// TODO migrate back to using testVariant in w3up access-api/test/delegations-storage.test.js
+test('should persist delegations', async (t) => {
+  const { dynamo, s3 } = t.context
+  const bucketName = await createBucket(s3)
+  const delegationsBucket = useDelegationsStore(s3, bucketName)
+  const delegationsStorage = useDelegationsTable(
+    dynamo,
+    await createTable(dynamo, delegationsTableProps),
+    delegationsBucket
+  )
+  const count = Math.round(Math.random() * 10)
+  const delegations = await Promise.all(
+    Array.from({ length: count }).map(() => createSampleDelegation())
+  )
+  await delegationsStorage.putMany(...delegations)
+  t.deepEqual(await delegationsStorage.count(), BigInt(delegations.length))
+})
+
+// TODO migrate back to using testVariant in w3up access-api/test/delegations-storage.test.js
+test('can retrieve delegations by audience', async (t) => {
+  const { dynamo, s3 } = t.context
+  const bucketName = await createBucket(s3)
+  const delegationsBucket = useDelegationsStore(s3, bucketName)
+  const delegations = useDelegationsTable(
+    dynamo,
+    await createTable(dynamo, delegationsTableProps),
+    delegationsBucket
+  )
+  const issuer = await principal.ed25519.generate()
+
+  const alice = await principal.ed25519.generate()
+  const delegationsForAlice = await Promise.all(
+    Array.from({ length: 1 }).map(() =>
+      createDelegation({ issuer, audience: alice })
+    )
+  )
+
+  const bob = await principal.ed25519.generate()
+  const delegationsForBob = await Promise.all(
+    Array.from({ length: 2 }).map((e, i) =>
+      createDelegation({
+        issuer,
+        audience: bob,
+        capabilities: [
+          {
+            can: `test/${i}`,
+            with: alice.did(),
+          },
+        ],
+      })
+    )
+  )
+
+  await delegations.putMany(...delegationsForAlice, ...delegationsForBob)
+
+  const aliceDelegations = await collect(
+    delegations.find({ audience: alice.did() })
+  )
+  t.deepEqual(aliceDelegations.length, delegationsForAlice.length)
+
+  const bobDelegations = await collect(
+    delegations.find({ audience: bob.did() })
+  )
+  t.deepEqual(bobDelegations.length, delegationsForBob.length)
+
+  const carol = await principal.ed25519.generate()
+  const carolDelegations = await collect(
+    delegations.find({ audience: carol.did() })
+  )
+  t.deepEqual(carolDelegations.length, 0)
+})
+

--- a/upload-api/test/service/delegations.test.js
+++ b/upload-api/test/service/delegations.test.js
@@ -1,9 +1,7 @@
 /* eslint-disable no-loop-func */
 import { test } from '../helpers/context.js'
 import * as principal from '@ucanto/principal'
-import * as Ucanto from '@ucanto/interface'
 import * as ucanto from '@ucanto/core'
-import * as assert from 'node:assert'
 import { collect } from 'streaming-iterables'
 import {
   createS3,
@@ -22,8 +20,8 @@ import { useDelegationsStore } from '../../buckets/delegations-store.js'
  * @param {object} options
  * @param {PromiseLike<principal.ed25519.EdSigner>} [options.audience]
  * @param {PromiseLike<principal.ed25519.EdSigner>} [options.issuer]
- * @param {Ucanto.URI} [options.with]
- * @param {Ucanto.Ability} [options.can]
+ * @param {import('@ucanto/interface').URI} [options.with]
+ * @param {import('@ucanto/interface').Ability} [options.can]
  */
 export async function createSampleDelegation(options = {}) {
   const {
@@ -45,14 +43,13 @@ export async function createSampleDelegation(options = {}) {
 }
 
 /**
+ * TODO: migrate back to function originally defined in w3up access-api/test/delegations-storage.testjs
  * 
- *  * TODO: migrate back to function originally defined in w3up access-api/test/delegations-storage.testjs
-
  * @param {object} [opts]
- * @param {Ucanto.Signer<Ucanto.DID>} [opts.issuer]
- * @param {Ucanto.Principal} [opts.audience]
- * @param {Ucanto.Capabilities} [opts.capabilities]
- * @returns {Promise<Ucanto.Delegation>}
+ * @param {import('@ucanto/interface').Signer<import('@ucanto/interface').DID>} [opts.issuer]
+ * @param {import('@ucanto/interface').Principal} [opts.audience]
+ * @param {import('@ucanto/interface').Capabilities} [opts.capabilities]
+ * @returns {Promise<import('@ucanto/interface').Delegation>}
  */
 async function createDelegation(opts = {}) {
   const {

--- a/upload-api/types.ts
+++ b/upload-api/types.ts
@@ -1,6 +1,7 @@
 import * as UCAN from '@ipld/dag-ucan'
 import { DID, Link, Delegation, Signature, Block } from '@ucanto/interface'
 import { UnknownLink } from 'multiformats'
+import { CID } from 'multiformats/cid'
 import { Kinesis } from '@aws-sdk/client-kinesis'
 
 
@@ -42,6 +43,11 @@ export interface TaskBucket {
 export interface WorkflowBucket {
   put: (Cid: string, bytes: Uint8Array) => Promise<void>
   get: (Cid: string) => Promise<Uint8Array|undefined>
+}
+
+export interface DelegationsBucket {
+  put: (cid: CID, bytes: Uint8Array) => Promise<void>
+  get: (cid: CID) => Promise<Uint8Array|undefined>
 }
 
 export interface UcanInvocation {


### PR DESCRIPTION
This is a first step toward https://github.com/web3-storage/w3up/issues/711 as documented in https://github.com/web3-storage/w3up/pull/744/files?short_path=4e012d9#diff-4e012d97ece45b455806fabbe1f93ce11af56213b9137463a427e1c5d4d8bda6

This is an implementation spike of storing delegations in DynamoDB rather than D1.

Because we already use DynamoDB in the upload-api, it made sense to reuse the configuration and testing infrastructure we've already built there. I copied a number of interfaces from https://github.com/web3-storage/w3up/tree/main/packages/access-api to get this done, and will migrate back to them soon.


Next steps:

- [] finish implementing provisions table
- [] port the delegations-related service endpoints (but *not* the service provider implementations!) in `w3up/access-api` over to this repository and get them running in an AWS Lambda
- [] decide whether we want to use R2 or S3 for delegations, point the S3 code in this PR at R2 if we want to use that
