### PR TITLE
feat: stop storing delegations in a bespoke bucket

### DIFF
--- a/upload-api/buckets/delegations-store.js
+++ b/upload-api/buckets/delegations-store.js
@@ -24,6 +24,25 @@ export function createDelegationsStore(region, bucketName, options = {}) {
 }
 
 /**
+ * 
+ * @param {string} endpoint 
+ * @param {string} accessKeyId 
+ * @param {string} secretAccessKey 
+ * @param {string} bucketName
+ */
+export function useR2DelegationsStore(endpoint, accessKeyId, secretAccessKey, bucketName){
+  const s3Client = new S3Client({
+    region: 'auto',
+    endpoint,
+    credentials: {
+      accessKeyId,
+      secretAccessKey,
+    },
+  })
+  return useDelegationsStore(s3Client, bucketName)
+}
+
+/**
  * @param { CID} cid
  */
 function createDelegationsBucketKey (cid) {

--- a/upload-api/buckets/delegations-store.js
+++ b/upload-api/buckets/delegations-store.js
@@ -10,27 +10,13 @@ import { base32 } from 'multiformats/bases/base32'
 
 /**
  * Abstraction layer with Factory to perform operations on bucket.
- *
- * @param {string} region
- * @param {string} bucketName
- * @param {import('@aws-sdk/client-s3').ServiceInputTypes} [options]
- */
-export function createR2DelegationsStore(region, bucketName, options = {}) {
-  const s3client = new S3Client({
-    region,
-    ...options,
-  })
-  return useDelegationsStore(s3client, bucketName)
-}
-
-/**
  * 
  * @param {string} endpoint 
  * @param {string} accessKeyId 
  * @param {string} secretAccessKey 
  * @param {string} bucketName
  */
-export function useR2DelegationsStore(endpoint, accessKeyId, secretAccessKey, bucketName){
+export function createR2DelegationsStore(endpoint, accessKeyId, secretAccessKey, bucketName){
   const s3Client = new S3Client({
     region: 'auto',
     endpoint,

--- a/upload-api/buckets/delegations-store.js
+++ b/upload-api/buckets/delegations-store.js
@@ -15,7 +15,7 @@ import { base32 } from 'multiformats/bases/base32'
  * @param {string} bucketName
  * @param {import('@aws-sdk/client-s3').ServiceInputTypes} [options]
  */
-export function createDelegationsStore(region, bucketName, options = {}) {
+export function createR2DelegationsStore(region, bucketName, options = {}) {
   const s3client = new S3Client({
     region,
     ...options,

--- a/upload-api/errors.js
+++ b/upload-api/errors.js
@@ -47,6 +47,24 @@ export class NoCarFoundForGivenReceiptError extends HTTPError {
 }
 NoCarFoundForGivenReceiptError.CODE = 'ERROR_CAR_NOT_FOUND_FOR_RECEIPT'
 
+export class NoInvocationFoundForGivenCidError extends HTTPError {
+  constructor (msg = 'No invocation found for CID') {
+    super(msg, 404)
+    this.name = 'NoInvocationFoundForGivenCid'
+    this.code = NoInvocationFoundForGivenCidError.CODE
+  }
+}
+NoInvocationFoundForGivenCidError.CODE = 'ERROR_INVOCATION_NOT_FOUND_FOR_CID'
+
+export class NoDelegationFoundForGivenCidError extends HTTPError {
+  constructor (msg = 'No delegation found for CID') {
+    super(msg, 404)
+    this.name = 'NoDelegationFoundForGivenCid'
+    this.code = NoDelegationFoundForGivenCidError.CODE
+  }
+}
+NoDelegationFoundForGivenCidError.CODE = 'ERROR_DELEGATION_NOT_FOUND_FOR_CID'
+
 export class NoTokenError extends HTTPError {
   constructor (msg = 'No token found in `Authorization: Basic ` header') {
     super(msg, 401)

--- a/upload-api/errors.js
+++ b/upload-api/errors.js
@@ -65,6 +65,15 @@ export class NoDelegationFoundForGivenCidError extends HTTPError {
 }
 NoDelegationFoundForGivenCidError.CODE = 'ERROR_DELEGATION_NOT_FOUND_FOR_CID'
 
+export class FailedToDecodeDelegationForGivenCidError extends HTTPError {
+  constructor (msg = 'Failed to decode delegation with given CID') {
+    super(msg, 404)
+    this.name = 'FailedToDecodeDelegationForGivenCid'
+    this.code = FailedToDecodeDelegationForGivenCidError.CODE
+  }
+}
+FailedToDecodeDelegationForGivenCidError.CODE = 'ERROR_DELEGATION_DECODE_FAILED_FOR_CID'
+
 export class NoTokenError extends HTTPError {
   constructor (msg = 'No token found in `Authorization: Basic ` header') {
     super(msg, 401)

--- a/upload-api/functions/ucan-invocation-router.js
+++ b/upload-api/functions/ucan-invocation-router.js
@@ -150,7 +150,7 @@ export async function ucanInvocationRouter (request) {
       /** @type {import('@web3-storage/upload-api').ServiceDID} */
       (accessServiceDID)
     ]),
-    delegationsStorage: createDelegationsTable(AWS_REGION, delegationTableName, delegationBucket)
+    delegationsStorage: createDelegationsTable(AWS_REGION, delegationTableName, delegationBucket, invocationBucket, workflowBucket)
   })
 
   const processingCtx = {

--- a/upload-api/functions/ucan-invocation-router.js
+++ b/upload-api/functions/ucan-invocation-router.js
@@ -19,7 +19,7 @@ import { CAR, Legacy, Codec } from '@ucanto/transport'
 import { Email } from '../email.js'
 import { useProvisionStore } from '../stores/provisions.js'
 import { createDelegationsTable } from '../tables/delegations.js'
-import { createDelegationsStore } from '../buckets/delegations-store.js'
+import { useR2DelegationsStore } from '../buckets/delegations-store.js'
 import { createSubscriptionTable } from '../tables/subscription.js'
 import { createConsumerTable } from '../tables/consumer.js'
 
@@ -86,6 +86,9 @@ export async function ucanInvocationRouter (request) {
     SUBSCRIPTION_TABLE_NAME: subscriptionTableName = '',
     DELEGATION_TABLE_NAME: delegationTableName = '',
     DELEGATION_BUCKET_NAME: delegationBucketName = '',
+    R2_DELEGATION_BUCKET_ENDPOINT: r2DelegationBucketEndpoint = '',
+    R2_DELEGATION_BUCKET_ACCESS_KEY_ID: r2DelegationBucketAccessKeyId = '',
+    R2_DELEGATION_BUCKET_SECRET_ACCESS_KEY: r2DelegationBucketSecretAccessKey = '',
     INVOCATION_BUCKET_NAME: invocationBucketName = '',
     TASK_BUCKET_NAME: taskBucketName = '',
     WORKFLOW_BUCKET_NAME: workflowBucketName = '',
@@ -113,7 +116,7 @@ export async function ucanInvocationRouter (request) {
   )
   const taskBucket = createTaskStore(AWS_REGION, taskBucketName)
   const workflowBucket = createWorkflowStore(AWS_REGION, workflowBucketName)
-  const delegationBucket = createDelegationsStore(AWS_REGION, delegationBucketName)
+  const delegationBucket = useR2DelegationsStore(r2DelegationBucketEndpoint, r2DelegationBucketAccessKeyId, r2DelegationBucketSecretAccessKey, delegationBucketName)
   const subscriptionTable = createSubscriptionTable(AWS_REGION, subscriptionTableName, {
     endpoint: dbEndpoint
   });

--- a/upload-api/functions/ucan-invocation-router.js
+++ b/upload-api/functions/ucan-invocation-router.js
@@ -85,10 +85,10 @@ export async function ucanInvocationRouter (request) {
     CONSUMER_TABLE_NAME: consumerTableName = '',
     SUBSCRIPTION_TABLE_NAME: subscriptionTableName = '',
     DELEGATION_TABLE_NAME: delegationTableName = '',
-    DELEGATION_BUCKET_NAME: delegationBucketName = '',
     R2_DELEGATION_BUCKET_ENDPOINT: r2DelegationBucketEndpoint = '',
     R2_DELEGATION_BUCKET_ACCESS_KEY_ID: r2DelegationBucketAccessKeyId = '',
     R2_DELEGATION_BUCKET_SECRET_ACCESS_KEY: r2DelegationBucketSecretAccessKey = '',
+    R2_DELEGATION_BUCKET_NAME: r2DelegationBucketName = '',
     INVOCATION_BUCKET_NAME: invocationBucketName = '',
     TASK_BUCKET_NAME: taskBucketName = '',
     WORKFLOW_BUCKET_NAME: workflowBucketName = '',
@@ -116,7 +116,7 @@ export async function ucanInvocationRouter (request) {
   )
   const taskBucket = createTaskStore(AWS_REGION, taskBucketName)
   const workflowBucket = createWorkflowStore(AWS_REGION, workflowBucketName)
-  const delegationBucket = useR2DelegationsStore(r2DelegationBucketEndpoint, r2DelegationBucketAccessKeyId, r2DelegationBucketSecretAccessKey, delegationBucketName)
+  const delegationBucket = useR2DelegationsStore(r2DelegationBucketEndpoint, r2DelegationBucketAccessKeyId, r2DelegationBucketSecretAccessKey, r2DelegationBucketName)
   const subscriptionTable = createSubscriptionTable(AWS_REGION, subscriptionTableName, {
     endpoint: dbEndpoint
   });

--- a/upload-api/functions/ucan-invocation-router.js
+++ b/upload-api/functions/ucan-invocation-router.js
@@ -153,7 +153,7 @@ export async function ucanInvocationRouter (request) {
       /** @type {import('@web3-storage/upload-api').ServiceDID} */
       (accessServiceDID)
     ]),
-    delegationsStorage: createDelegationsTable(AWS_REGION, delegationTableName, delegationBucket, invocationBucket, workflowBucket)
+    delegationsStorage: createDelegationsTable(AWS_REGION, delegationTableName, { bucket: delegationBucket, invocationBucket, workflowBucket })
   })
 
   const processingCtx = {

--- a/upload-api/functions/validate-email.js
+++ b/upload-api/functions/validate-email.js
@@ -3,7 +3,7 @@ import { authorize } from '@web3-storage/upload-api/validate'
 import { getServiceSigner } from '../config.js'
 import { Email } from '../email.js'
 import { createDelegationsTable } from '../tables/delegations.js'
-import { createDelegationsStore } from '../buckets/delegations-store.js'
+import { createR2DelegationsStore } from '../buckets/delegations-store.js'
 import { createInvocationStore } from '../buckets/invocation-store.js'
 import { createWorkflowStore } from '../buckets/workflow-store.js'
 import { createSubscriptionTable } from '../tables/subscription.js'
@@ -62,7 +62,7 @@ function createAuthorizeContext () {
     INVOCATION_BUCKET_NAME
   )
   const workflowBucket = createWorkflowStore(AWS_REGION, WORKFLOW_BUCKET_NAME)
-  const delegationBucket = createDelegationsStore(AWS_REGION, DELEGATION_BUCKET_NAME)
+  const delegationBucket = createR2DelegationsStore(AWS_REGION, DELEGATION_BUCKET_NAME)
   const subscriptionTable = createSubscriptionTable(AWS_REGION, SUBSCRIPTION_TABLE_NAME, {
     endpoint: dbEndpoint
   });

--- a/upload-api/functions/validate-email.js
+++ b/upload-api/functions/validate-email.js
@@ -4,8 +4,11 @@ import { getServiceSigner } from '../config.js'
 import { Email } from '../email.js'
 import { createDelegationsTable } from '../tables/delegations.js'
 import { createDelegationsStore } from '../buckets/delegations-store.js'
+import { createInvocationStore } from '../buckets/invocation-store.js'
+import { createWorkflowStore } from '../buckets/workflow-store.js'
 import { createSubscriptionTable } from '../tables/subscription.js'
 import { createConsumerTable } from '../tables/consumer.js'
+
 import { useProvisionStore } from '../stores/provisions.js'
 import {
   HtmlResponse,
@@ -44,6 +47,8 @@ function createAuthorizeContext () {
     AWS_REGION = '',
     DELEGATION_TABLE_NAME = '',
     DELEGATION_BUCKET_NAME = '',
+    INVOCATION_BUCKET_NAME = '',
+    WORKFLOW_BUCKET_NAME = '',
     POSTMARK_TOKEN = '',
     PRIVATE_KEY = '',
     SUBSCRIPTION_TABLE_NAME = '',
@@ -52,6 +57,11 @@ function createAuthorizeContext () {
     // set for testing
     DYNAMO_DB_ENDPOINT: dbEndpoint,
   } = process.env
+  const invocationBucket = createInvocationStore(
+    AWS_REGION,
+    INVOCATION_BUCKET_NAME
+  )
+  const workflowBucket = createWorkflowStore(AWS_REGION, WORKFLOW_BUCKET_NAME)
   const delegationBucket = createDelegationsStore(AWS_REGION, DELEGATION_BUCKET_NAME)
   const subscriptionTable = createSubscriptionTable(AWS_REGION, SUBSCRIPTION_TABLE_NAME, {
     endpoint: dbEndpoint
@@ -64,7 +74,7 @@ function createAuthorizeContext () {
     url: new URL(ACCESS_SERVICE_URL),
     email: new Email({ token: POSTMARK_TOKEN }),
     signer: getServiceSigner({ UPLOAD_API_DID, PRIVATE_KEY }),
-    delegationsStorage: createDelegationsTable(AWS_REGION, DELEGATION_TABLE_NAME, delegationBucket),
+    delegationsStorage: createDelegationsTable(AWS_REGION, DELEGATION_TABLE_NAME, delegationBucket, invocationBucket, workflowBucket),
     provisionsStorage: useProvisionStore(subscriptionTable, consumerTable, [
       /** @type {import('@web3-storage/upload-api').ServiceDID} */
       (ACCESS_SERVICE_DID)

--- a/upload-api/functions/validate-email.js
+++ b/upload-api/functions/validate-email.js
@@ -74,7 +74,7 @@ function createAuthorizeContext () {
     url: new URL(ACCESS_SERVICE_URL),
     email: new Email({ token: POSTMARK_TOKEN }),
     signer: getServiceSigner({ UPLOAD_API_DID, PRIVATE_KEY }),
-    delegationsStorage: createDelegationsTable(AWS_REGION, DELEGATION_TABLE_NAME, delegationBucket, invocationBucket, workflowBucket),
+    delegationsStorage: createDelegationsTable(AWS_REGION, DELEGATION_TABLE_NAME, { bucket: delegationBucket, invocationBucket, workflowBucket }),
     provisionsStorage: useProvisionStore(subscriptionTable, consumerTable, [
       /** @type {import('@web3-storage/upload-api').ServiceDID} */
       (ACCESS_SERVICE_DID)

--- a/upload-api/tables/delegations.js
+++ b/upload-api/tables/delegations.js
@@ -106,8 +106,8 @@ export function useDelegationsTable (dynamoDb, tableName, bucket, invocationBuck
         if (cause) {
           delegations.push(await findDelegationInInvocation(
             invocationBucket, workflowBucket,
-            CID.parse(cause), delegationCid)
-          )
+            CID.parse(cause), delegationCid
+          ))
         } else {
           delegations.push(await cidToDelegation(bucket, delegationCid))
         }

--- a/upload-api/tables/delegations.js
+++ b/upload-api/tables/delegations.js
@@ -1,3 +1,4 @@
+import * as CAR from '@ucanto/transport/car'
 import { base32 } from 'multiformats/bases/base32'
 import {
   DynamoDBClient,
@@ -10,10 +11,13 @@ import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
 import { CID } from 'multiformats/cid'
 import {
   bytesToDelegations,
-  delegationsToBytes
 } from '@web3-storage/access/encoding'
 // eslint-disable-next-line no-unused-vars
 import * as Ucanto from '@ucanto/interface'
+import {
+  NoInvocationFoundForGivenReceiptError,
+  NoCarFoundForGivenReceiptError,
+} from '../errors.js'
 
 /**
  * @typedef {Ucanto.Delegation} Delegation
@@ -25,46 +29,49 @@ import * as Ucanto from '@ucanto/interface'
  * @param {string} region
  * @param {string} tableName
  * @param {import('../types').DelegationsBucket} bucket
+ * @param {import('../types').InvocationBucket} invocationBucket
+ * @param {import('../types').WorkflowBucket} workflowBucket
  * @param {object} [options]
  * @param {string} [options.endpoint]
  */
-export function createDelegationsTable (region, tableName, bucket, options = {}) {
+export function createDelegationsTable (region, tableName, bucket, invocationBucket, workflowBucket, options = {}) {
   const dynamoDb = new DynamoDBClient({
     region,
     endpoint: options.endpoint,
   })
 
-  return useDelegationsTable(dynamoDb, tableName, bucket)
+  return useDelegationsTable(dynamoDb, tableName, bucket, invocationBucket, workflowBucket)
 }
 
 /**
  * @param {DynamoDBClient} dynamoDb
  * @param {string} tableName
  * @param {import('../types').DelegationsBucket} bucket
+ * @param {import('../types').InvocationBucket} invocationBucket
+ * @param {import('../types').WorkflowBucket} workflowBucket
  * @returns {import('@web3-storage/upload-api').DelegationsStorage}
  */
-export function useDelegationsTable (dynamoDb, tableName, bucket) {
+export function useDelegationsTable (dynamoDb, tableName, bucket, invocationBucket, workflowBucket) {
   return {
-    putMany: async (...delegations) => {
+    putMany: async (cause, ...delegations) => {
       if (delegations.length === 0) {
         return {
           ok: {}
         }
       }
-      await writeDelegations(bucket, delegations)
-      // TODO: we should look at the return value of this BatchWriteItemCommand and either retry or clean up delegations that we fail to index
       await dynamoDb.send(new BatchWriteItemCommand({
         RequestItems: {
           [tableName]: delegations.map(d => ({
             PutRequest: {
               Item: marshall(
-                createDelegationItem(d),
+                createDelegationItem(cause, d),
                 { removeUndefinedValues: true })
             }
           })
           )
         }
       }))
+      // TODO: we should look at the return value of this BatchWriteItemCommand and either retry unprocessed items or return a Failure
       return {
         ok: {}
       }
@@ -94,8 +101,16 @@ export function useDelegationsTable (dynamoDb, tableName, bucket) {
 
       const delegations = []
       for (const result of response.Items ?? []) {
-        const { link } = unmarshall(result)
-        delegations.push(await cidToDelegation(bucket, CID.parse(link)))
+        const { cause, link } = unmarshall(result)
+        const delegationCid = CID.parse(link)
+        if (cause) {
+          delegations.push(await findDelegationInInvocation(
+            invocationBucket, workflowBucket,
+            CID.parse(cause), delegationCid)
+          )
+        } else {
+          delegations.push(await cidToDelegation(bucket, delegationCid))
+        }
       }
       return {
         ok: delegations
@@ -105,11 +120,13 @@ export function useDelegationsTable (dynamoDb, tableName, bucket) {
 }
 
 /**
+ * @param {Ucanto.Link} cause
  * @param {Delegation} d
- * @returns {{link: string, audience: string, issuer: string}}}
+ * @returns {{cause: string, link: string, audience: string, issuer: string}}}
  */
-function createDelegationItem (d) {
+function createDelegationItem (cause, d) {
   return {
+    cause: cause.toString(),
     link: d.cid.toString(),
     audience: d.audience.did(),
     issuer: d.issuer.did(),
@@ -134,27 +151,54 @@ async function cidToDelegation (bucket, cid) {
   return delegation
 }
 
-/**
- * 
- * @param {import('../types').DelegationsBucket} bucket
- * @param {Ucanto.Delegation<Ucanto.Tuple<Ucanto.Capability>>[]} delegations
+/** 
+ * @param {import('../types').InvocationBucket} invocationBucket
+ * @param {import('../types').WorkflowBucket} workflowBucket
+ * @param {CID} invocationCid
+ * @param {CID} delegationCid
+ * @returns {Promise<Ucanto.Delegation>}
  */
-async function writeDelegations (bucket, delegations) {
-  return writeEntries(
-    bucket,
-    [...delegations].map((delegation) => {
-      const carBytes = delegationsToBytes([delegation])
-      const value = carBytes
-      return /** @type {[key: CID, value: Uint8Array]} */ ([delegation.cid, value])
-    })
-  )
-}
+async function findDelegationInInvocation (invocationBucket, workflowBucket, invocationCid, delegationCid) {
 
-/**
- * 
- * @param {import('../types').DelegationsBucket} bucket
- * @param {Iterable<readonly [key: CID, value: Uint8Array ]>} entries
- */
-async function writeEntries (bucket, entries) {
-  await Promise.all([...entries].map(([key, value]) => bucket.put(key, value)))
+  // TODO is this right? I cargo culted some code from ucan-invocation.js and w3up/upload-api/src/access/delegate.js
+  // but am not highly confident it works
+
+  const invocationCidStr = invocationCid.toString()
+  const agentMessageWithInvocationCid = await invocationBucket.getInLink(
+    invocationCid.toString()
+  )
+
+  if (!agentMessageWithInvocationCid) {
+    throw new NoCarFoundForGivenReceiptError()
+  }
+
+  const agentMessageBytes = await workflowBucket.get(
+    agentMessageWithInvocationCid
+  )
+  if (!agentMessageBytes) {
+    throw new NoCarFoundForGivenReceiptError()
+  }
+
+  const agentMessage = await CAR.request.decode({
+    body: agentMessageBytes,
+    headers: {},
+  })
+  const invocation = agentMessage.invocations.find(
+    (inv) => inv.cid.toString() === invocationCidStr
+  )
+
+  if (!invocation) {
+    throw new NoInvocationFoundForGivenReceiptError()
+  }
+
+  const proofDelegations = invocation.proofs.flatMap((proof) =>
+    'capabilities' in proof ? [proof] : []
+  )
+  const foundDelegation = proofDelegations.find(proof => proof.cid)
+
+  if (!foundDelegation) {
+    throw new NoInvocationFoundForGivenReceiptError()
+  }
+
+  return foundDelegation
 }

--- a/upload-api/tables/delegations.js
+++ b/upload-api/tables/delegations.js
@@ -15,8 +15,8 @@ import {
 // eslint-disable-next-line no-unused-vars
 import * as Ucanto from '@ucanto/interface'
 import {
-  NoInvocationFoundForGivenReceiptError,
-  NoCarFoundForGivenReceiptError,
+  NoInvocationFoundForGivenCidError,
+  NoDelegationFoundForGivenCidError
 } from '../errors.js'
 
 /**
@@ -169,14 +169,14 @@ async function findDelegationInInvocation (invocationBucket, workflowBucket, inv
   )
 
   if (!agentMessageWithInvocationCid) {
-    throw new NoCarFoundForGivenReceiptError()
+    throw new NoInvocationFoundForGivenCidError()
   }
 
   const agentMessageBytes = await workflowBucket.get(
     agentMessageWithInvocationCid
   )
   if (!agentMessageBytes) {
-    throw new NoCarFoundForGivenReceiptError()
+    throw new NoInvocationFoundForGivenCidError()
   }
 
   const agentMessage = await CAR.request.decode({
@@ -188,7 +188,7 @@ async function findDelegationInInvocation (invocationBucket, workflowBucket, inv
   )
 
   if (!invocation) {
-    throw new NoInvocationFoundForGivenReceiptError()
+    throw new NoInvocationFoundForGivenCidError()
   }
 
   const proofDelegations = invocation.proofs.flatMap((proof) =>
@@ -197,7 +197,7 @@ async function findDelegationInInvocation (invocationBucket, workflowBucket, inv
   const foundDelegation = proofDelegations.find(proof => proof.cid)
 
   if (!foundDelegation) {
-    throw new NoInvocationFoundForGivenReceiptError()
+    throw new NoDelegationFoundForGivenCidError()
   }
 
   return foundDelegation

--- a/upload-api/tables/index.js
+++ b/upload-api/tables/index.js
@@ -30,7 +30,8 @@ export const uploadTableProps = {
 /** @type TableProps */
 export const delegationTableProps = {
   fields: {
-    link: 'string',        // `baf...x`
+    cause: 'string',      // `baf...x`(CID of the invocation)
+    link: 'string',       // `baf...x` (CID of the delegation)
     audience: 'string',   // `did:web:service`
     issuer: 'string',     // `did:key:agent`
     expiration: 'string', // `9256939505` (unix timestamp)
@@ -41,25 +42,6 @@ export const delegationTableProps = {
   // we want to query by audience, but that won't necessarily be unique, so use cid as sortKey
   primaryIndex: { partitionKey: 'audience', sortKey: 'link' },
 }
-
-/** @type TableProps */
-export const provisionTableProps = {
-  fields: {
-    cid: 'string',        // `baf...x` (CID of invocation that created this provision)
-    consumer: 'string',   // `did:key:space` (DID of the actor that is consuming the provider, e.g. a space DID)
-    provider: 'string',   // `did:web:service` (DID of the provider, e.g. a storage provider)
-    customer: 'string',    // `did:key:agent` (DID of the actor that authorized this provision)
-    insertedAt: 'string', // `2022-12-24T...`
-    updatedAt: 'string',  // `2022-12-24T...`
-  },
-  // TODO does this index setup seem right?
-  // we want to query by consumer, and I think it should be unique?
-  // TODO also are we sure that a single invocation will only create a single provision? the D1 schema used CID as a PRIMARY KEY so I think this should be fine, but will it always be true?
-  primaryIndex: { partitionKey: 'consumer' },
-}
-
-/** VS */
-
 
 /** @type TableProps */
 export const subscriptionTableProps = {

--- a/upload-api/tables/index.js
+++ b/upload-api/tables/index.js
@@ -56,6 +56,7 @@ export const subscriptionTableProps = {
   // TODO does this index setup seem right?
   primaryIndex: { partitionKey: 'customer', sortKey: 'subscription' },
   globalIndexes: {
+    // TODO: I don't think we should keep this index - partitioning by provider is basically useless and won't be much faster than a table scan
     provider: { partitionKey: 'provider', projection: ['customer'] }
   }
 }
@@ -73,6 +74,7 @@ export const consumerTableProps = {
   // TODO does this index setup seem right?
   primaryIndex: { partitionKey: 'consumer', sortKey: 'subscription' },
   globalIndexes: {
+    // TODO: I don't think we should keep this index - partitioning by provider is basically useless and won't be much faster than a table scan
     provider: { partitionKey: 'provider', projection: ['consumer'] }
   }
 }

--- a/upload-api/tables/subscription.js
+++ b/upload-api/tables/subscription.js
@@ -5,7 +5,7 @@ import {
   QueryCommand,
 } from '@aws-sdk/client-dynamodb'
 import { Failure } from '@ucanto/server'
-import { marshall } from '@aws-sdk/util-dynamodb'
+import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
 
 /**
  * @typedef {import('../types').SubscriptionTable} SubscriptionTable
@@ -128,6 +128,21 @@ export function useSubscriptionTable (dynamoDb, tableName) {
       })
       const response = await dynamoDb.send(cmd)
       return response.Items ? /** @type { import('@ucanto/interface').DID } */ (response.Items[0].customer.S) : undefined
+    },
+
+    findSubscriptionsForCustomer: async (customer) => {
+      const cmd = new QueryCommand({
+        TableName: tableName,
+        KeyConditions: {
+          customer: {
+            ComparisonOperator: 'EQ',
+            AttributeValueList: [{ S: customer }]
+          }
+        },
+        AttributesToGet: ['subscription']
+      })
+      const response = await dynamoDb.send(cmd)
+      return response.Items?.map(i => unmarshall(i).subscription)
     }
   }
 }

--- a/upload-api/test/queries.test.js
+++ b/upload-api/test/queries.test.js
@@ -137,6 +137,9 @@ test('provider getting per customer/consumer/subscription stats', async (t) => {
 
 
 test('space finding its providers/subscribers', async (t) => {
+  const { consumers, consumer, subscription } = await consumersTestFixture(t.context)
+  const foundSubscriptions = await consumers.findSubscriptionsForConsumer(consumer)
+  t.deepEqual(foundSubscriptions, [subscription])
 })
 
 test('space removing a provider', async (t) => {
@@ -150,6 +153,9 @@ test('customer canceling its subscription', async (t) => {
 })
 
 test('customer listing its subscription', async (t) => {
+  const { subscriptions, customer, subscription } = await subscriptionsTestFixture(t.context)
+  const foundSubscriptions = await subscriptions.findSubscriptionsForCustomer(customer)
+  t.deepEqual(foundSubscriptions, [subscription])
 })
 
 test('customer getting subscription stats (data stored, etc)', async (t) => {

--- a/upload-api/test/service/delegations.test.js
+++ b/upload-api/test/service/delegations.test.js
@@ -27,13 +27,15 @@ testDelegationsStorageVariant(
     const invocationsBucketName = await createBucket(s3)
     const workflowBucketName = await createBucket(s3)
 
-    
+
     return useDelegationsTable(
       dynamo,
       await createTable(dynamo, delegationTableProps),
-      useDelegationsStore(s3, delegationsBucketName),
-      useInvocationStore(s3, invocationsBucketName),
-      useWorkflowStore(s3, workflowBucketName)
+      {
+        bucket: useDelegationsStore (s3, delegationsBucketName),
+        invocationBucket: useInvocationStore (s3, invocationsBucketName),
+        workflowBucket: useWorkflowStore (s3, workflowBucketName)
+      }
     )
   },
   test

--- a/upload-api/test/service/delegations.test.js
+++ b/upload-api/test/service/delegations.test.js
@@ -10,6 +10,8 @@ import {
 import { delegationTableProps } from '../../tables/index.js'
 import { useDelegationsTable } from '../../tables/delegations.js'
 import { useDelegationsStore } from '../../buckets/delegations-store.js'
+import { useInvocationStore } from '../../buckets/invocation-store.js'
+import { useWorkflowStore } from '../../buckets/workflow-store.js'
 
 test.before(async (t) => {
   Object.assign(t.context, {
@@ -21,12 +23,17 @@ test.before(async (t) => {
 testDelegationsStorageVariant(
   async (/** @type {any} */ t) => {
     const { dynamo, s3 } = t.context
-    const bucketName = await createBucket(s3)
+    const delegationsBucketName = await createBucket(s3)
+    const invocationsBucketName = await createBucket(s3)
+    const workflowBucketName = await createBucket(s3)
+
     
     return useDelegationsTable(
       dynamo,
       await createTable(dynamo, delegationTableProps),
-      useDelegationsStore(s3, bucketName)
+      useDelegationsStore(s3, delegationsBucketName),
+      useInvocationStore(s3, invocationsBucketName),
+      useWorkflowStore(s3, workflowBucketName)
     )
   },
   test

--- a/upload-api/types.ts
+++ b/upload-api/types.ts
@@ -69,6 +69,7 @@ export interface SubscriptionTable {
 export interface UnstableSubscriptionTable extends SubscriptionTable {
   findCustomersByProvider: (provider: DID) => Promise<DID[]>
   findCustomerForSubscription: (subscription: string) => Promise<DID | undefined>
+  findSubscriptionsForCustomer: (customer: string) => Promise<DID[] | undefined>
 }
 
 export interface ConsumerInput {


### PR DESCRIPTION
Since we already store delegations inside invocations in the invocation log, we can simply store the invocation CID and delegation CID and then fetch and find the needed delegations when they are requested.

I'm not sure the implementation is correct, as I'm not super familiar with the distinction between invocations, workflows and receipts, but the types all check out!

Would love careful review on the new `findDelegationInInvocation` method I've added to `upload-api/tables/delegations.js`