### PR TITLE
feat: roundabout supports redirect to raw key with bucket as query param

### DIFF
--- a/docs/roundabout.md
+++ b/docs/roundabout.md
@@ -1,6 +1,6 @@
 # Roundabout
 
-> Roundabout allows the creation of short lived presigned URLs for content stored in carpark bucket (in R2). It can also get the HTTP request redirected to the given presigned URL.
+> Roundabout allows the creation of short lived presigned URLs for content stored in web3.storage buckets (in R2). It can also get the HTTP request redirected to the given presigned URL.
 
 ## HTTP API
 
@@ -8,7 +8,13 @@ The given API is currently public.
 
 ### `GET /{carCid}`
 
-Redirects to a URL where the requested CAR file (by its CID) can be downloaded from. The request will return a `302 Redirect` to a created presigned URL.
+Redirects to a presigned URL where the requested CAR file (by its CID) can be downloaded from. This will use web3.storage `carpark` as the location of the requested CARs. The request will return a `302 Redirect` to a created presigned URL.
+
+It also supports a query parameter `expires` with the number of seconds this presigned URL should be valid for. You can set a value from one second to 7 days (604,800 seconds). By default the expiration is set for 3 days (259,200 seconds).
+
+### `GET /raw/{key}?bucket=bucket-name`
+
+Redirects to a presigned URL where the requested bucket value can be downloaded from by its key. Unlike `GET /{carCid}`, this endpoint takes a raw key and is compatible with any web3.storage account bucket. The request will return a `302 Redirect` to a created presigned URL.
 
 It also supports a query parameter `expires` with the number of seconds this presigned URL should be valid for. You can set a value from one second to 7 days (604,800 seconds). By default the expiration is set for 3 days (259,200 seconds).
 
@@ -34,7 +40,7 @@ location: https://carpark-prod-0.fffa4b4363a7e5250af8357087263b3a.r2.cloudflares
 apigw-requestid: G3T3xg1LvHcEPxA=
 ```
 
-### Get presigned URL with custom expiration
+### Get presigned URL for CAR file with custom expiration via CURL
 
 ```console
 curl --head https://roundabout.web3.storage/bagbaiera222226db4v4oli5fldqghzgbv5rqv3n4ykyfxk7shfr42bfnqwua?expires=900
@@ -44,4 +50,10 @@ date: Wed, 21 Jun 2023 10:12:15 GMT
 content-length: 0
 location: https://carpark-prod-0.fffa4b4363a7e5250af8357087263b3a.r2.cloudflarestorage.com/bagbaiera222226db4v4oli5fldqghzgbv5rqv3n4ykyfxk7shfr42bfnqwua/bagbaiera222226db4v4oli5fldqghzgbv5rqv3n4ykyfxk7shfr42bfnqwua.car?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=a314d2872c5c092e911e3e2c7b5e5c3f%2F20230621%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20230621T101215Z&X-Amz-Expires=900&X-Amz-Signature=f61b984f0dad126f0f8e151cbb2eb0b9e10adb68b4ead7a0263a044a5b1985a9&X-Amz-SignedHeaders=host&x-id=GetObject
 apigw-requestid: G3T3xg1LvHcEPxA=
+```
+
+### Get presigned URL for raw file with custom bucket via CURL
+
+```console
+curl -L https://roundabout.web3.storage/raw/0000c19bd9cd7fa9c532eba81428eda0_baga6ea4seaqpohse35l4xucs5mtabgewpp4mgtle7yym7em6ouvhgjb7wc2pcmq.car?bucket\=dagcargo
 ```

--- a/docs/roundabout.md
+++ b/docs/roundabout.md
@@ -12,9 +12,9 @@ Redirects to a presigned URL where the requested CAR file (by its CID) can be do
 
 It also supports a query parameter `expires` with the number of seconds this presigned URL should be valid for. You can set a value from one second to 7 days (604,800 seconds). By default the expiration is set for 3 days (259,200 seconds).
 
-### `GET /raw/{key}?bucket=bucket-name`
+### `GET /key/{key}?bucket=bucket-name`
 
-Redirects to a presigned URL where the requested bucket value can be downloaded from by its key. Unlike `GET /{carCid}`, this endpoint takes a raw key and is compatible with any web3.storage account bucket. The request will return a `302 Redirect` to a created presigned URL.
+Redirects to a presigned URL where the requested bucket value can be downloaded from by its key. Unlike `GET /{carCid}`, this endpoint takes a key and is compatible with any web3.storage account bucket. The request will return a `302 Redirect` to a created presigned URL.
 
 It also supports a query parameter `expires` with the number of seconds this presigned URL should be valid for. You can set a value from one second to 7 days (604,800 seconds). By default the expiration is set for 3 days (259,200 seconds).
 
@@ -52,8 +52,8 @@ location: https://carpark-prod-0.fffa4b4363a7e5250af8357087263b3a.r2.cloudflares
 apigw-requestid: G3T3xg1LvHcEPxA=
 ```
 
-### Get presigned URL for raw file with custom bucket via CURL
+### Get presigned URL for file with key and custom bucket via CURL
 
 ```console
-curl -L https://roundabout.web3.storage/raw/0000c19bd9cd7fa9c532eba81428eda0_baga6ea4seaqpohse35l4xucs5mtabgewpp4mgtle7yym7em6ouvhgjb7wc2pcmq.car?bucket\=dagcargo
+curl -L https://roundabout.web3.storage/key/0000c19bd9cd7fa9c532eba81428eda0_baga6ea4seaqpohse35l4xucs5mtabgewpp4mgtle7yym7em6ouvhgjb7wc2pcmq.car?bucket\=dagcargo
 ```

--- a/docs/roundabout.md
+++ b/docs/roundabout.md
@@ -18,6 +18,8 @@ Redirects to a presigned URL where the requested bucket value can be downloaded 
 
 It also supports a query parameter `expires` with the number of seconds this presigned URL should be valid for. You can set a value from one second to 7 days (604,800 seconds). By default the expiration is set for 3 days (259,200 seconds).
 
+Note that there is a bucket list of accepted buckets.
+
 ## Usage
 
 ### Download CAR file via CURL

--- a/roundabout/functions/redirect.js
+++ b/roundabout/functions/redirect.js
@@ -44,11 +44,11 @@ export async function redirectCarGet(request) {
 }
 
 /**
- * AWS HTTP Gateway handler for GET /raw/{key} by bucket key
+ * AWS HTTP Gateway handler for GET /key/{key} by bucket key
  *
  * @param {import('aws-lambda').APIGatewayProxyEventV2} request
  */
-export async function redirectRawGet(request) {
+export async function redirectKeyGet(request) {
   const { BUCKET_NAME } = getEnv()
   const s3Client = getS3Client()
 
@@ -115,4 +115,4 @@ function getS3Client(){
 }
 
 export const handler = Sentry.AWSLambda.wrapHandler(redirectCarGet)
-export const rawHandler = Sentry.AWSLambda.wrapHandler(redirectRawGet)
+export const keyHandler = Sentry.AWSLambda.wrapHandler(redirectKeyGet)

--- a/roundabout/functions/redirect.js
+++ b/roundabout/functions/redirect.js
@@ -49,14 +49,13 @@ export async function redirectCarGet(request) {
  * @param {import('aws-lambda').APIGatewayProxyEventV2} request
  */
 export async function redirectKeyGet(request) {
-  const { BUCKET_NAME } = getEnv()
   const s3Client = getS3Client()
 
   let key, expiresIn, bucketName
   try {
     const parsedQueryParams = parseQueryStringParameters(request.queryStringParameters)
     expiresIn = parsedQueryParams.expiresIn
-    bucketName = parsedQueryParams.bucketName || BUCKET_NAME
+    bucketName = parsedQueryParams.bucketName
 
     key = request.pathParameters?.key
     if (!key) {

--- a/roundabout/functions/redirect.js
+++ b/roundabout/functions/redirect.js
@@ -12,18 +12,13 @@ Sentry.AWSLambda.init({
 })
 
 /**
- * AWS HTTP Gateway handler for GET /{cid}
+ * AWS HTTP Gateway handler for GET /{cid} by car CID
  *
  * @param {import('aws-lambda').APIGatewayProxyEventV2} request
  */
-export async function redirectGet(request) {
-  const {
-    BUCKET_ENDPOINT,
-    BUCKET_REGION,
-    BUCKET_ACCESS_KEY_ID,
-    BUCKET_SECRET_ACCESS_KEY,
-    BUCKET_NAME,
-  } = getEnv()
+export async function redirectCarGet(request) {
+  const { BUCKET_NAME } = getEnv()
+  const s3Client = getS3Client()
 
   let cid, expiresIn
   try {
@@ -39,19 +34,54 @@ export async function redirectGet(request) {
     }
   }
 
-  const s3Client = new S3Client({
-    region: BUCKET_REGION,
-    endpoint: BUCKET_ENDPOINT,
-    credentials: {
-      accessKeyId: BUCKET_ACCESS_KEY_ID,
-      secretAccessKey: BUCKET_SECRET_ACCESS_KEY,
-    },
-  })
-
   const signer = getSigner(s3Client, BUCKET_NAME)
-  const signedUrl = await signer.getUrl(cid, {
+  const key = `${cid}/${cid}.car`
+  const signedUrl = await signer.getUrl(key, {
     expiresIn
   })
+  
+  return toLambdaResponse(signedUrl)
+}
+
+/**
+ * AWS HTTP Gateway handler for GET /raw/{key} by bucket key
+ *
+ * @param {import('aws-lambda').APIGatewayProxyEventV2} request
+ */
+export async function redirectRawGet(request) {
+  const { BUCKET_NAME } = getEnv()
+  const s3Client = getS3Client()
+
+  let key, expiresIn, bucketName
+  try {
+    const parsedQueryParams = parseQueryStringParameters(request.queryStringParameters)
+    expiresIn = parsedQueryParams.expiresIn
+    bucketName = parsedQueryParams.bucketName || BUCKET_NAME
+
+    key = request.pathParameters?.key
+    if (!key) {
+      throw new Error('no path key provided')
+    }
+
+  } catch (err) {
+    return {
+      body: err.message,
+      statusCode: 400
+    }
+  }
+
+  const signer = getSigner(s3Client, bucketName)
+  const signedUrl = await signer.getUrl(key, {
+    expiresIn
+  })
+  
+  return toLambdaResponse(signedUrl)
+}
+
+/**
+ * @param {string | undefined} signedUrl 
+ */
+function toLambdaResponse(signedUrl) {
   if (!signedUrl) {
     return {
       statusCode: 404
@@ -66,4 +96,23 @@ export async function redirectGet(request) {
   }
 }
 
-export const handler = Sentry.AWSLambda.wrapHandler(redirectGet)
+function getS3Client(){
+  const {
+    BUCKET_ENDPOINT,
+    BUCKET_REGION,
+    BUCKET_ACCESS_KEY_ID,
+    BUCKET_SECRET_ACCESS_KEY,
+  } = getEnv()
+
+  return new S3Client({
+    region: BUCKET_REGION,
+    endpoint: BUCKET_ENDPOINT,
+    credentials: {
+      accessKeyId: BUCKET_ACCESS_KEY_ID,
+      secretAccessKey: BUCKET_SECRET_ACCESS_KEY,
+    },
+  })
+}
+
+export const handler = Sentry.AWSLambda.wrapHandler(redirectCarGet)
+export const rawHandler = Sentry.AWSLambda.wrapHandler(redirectRawGet)

--- a/roundabout/index.js
+++ b/roundabout/index.js
@@ -17,12 +17,10 @@ export function getSigner (s3Client, bucketName) {
   return {
     /**
      * 
-     * @param {import('multiformats').CID} cid
+     * @param {string} key
      * @param {RequestPresigningArguments} [options]
      */
-    getUrl: async (cid, options) => {
-      const key = `${cid}/${cid}.car`
-
+    getUrl: async (key, options) => {
       // Validate bucket has requested cid
       const headCommand = new HeadObjectCommand({
         Bucket: bucketName,

--- a/roundabout/test/index.test.js
+++ b/roundabout/test/index.test.js
@@ -62,6 +62,14 @@ test('parses valid expires', t => {
   t.is(param.expiresIn, parseInt(queryParams.expires))
 })
 
+test('parses bucket name', t => {
+  const queryParams = {
+    bucket: 'dagcargo'
+  }
+  const param = parseQueryStringParameters(queryParams)
+  t.is(param.bucketName, queryParams.bucket)
+})
+
 test('parses valid expires query parameter', t => {
   const queryParams = {
     expires: '900'

--- a/roundabout/test/index.test.js
+++ b/roundabout/test/index.test.js
@@ -70,6 +70,13 @@ test('parses bucket name', t => {
   t.is(param.bucketName, queryParams.bucket)
 })
 
+test('fails to parse bucket name not accepted', t => {
+  const queryParams = {
+    bucket: 'dagcargo-not-this'
+  }
+  t.throws(() => parseQueryStringParameters(queryParams))
+})
+
 test('parses valid expires query parameter', t => {
   const queryParams = {
     expires: '900'

--- a/roundabout/test/index.test.js
+++ b/roundabout/test/index.test.js
@@ -33,7 +33,8 @@ test('can create signed url for object in bucket', async t => {
   const expiresIn = 3 * 24 * 60 * 60 // 3 days in seconds
 
   const signer = getSigner(t.context.s3Client, bucketName)
-  const signedUrl = await signer.getUrl(carCid, {
+  const key = `${carCid}/${carCid}.car`
+  const signedUrl = await signer.getUrl(key, {
     expiresIn
   })
 
@@ -47,7 +48,8 @@ test('fails to create signed url for object not in bucket', async t => {
   const carCid = CID.parse('bagbaiera222226db4v4oli5fldqghzgbv5rqv3n4ykyfxk7shfr42bfnqwua')
 
   const signer = getSigner(t.context.s3Client, bucketName)
-  const signedUrl = await signer.getUrl(carCid)
+  const key = `${carCid}/${carCid}.car`
+  const signedUrl = await signer.getUrl(key)
 
   t.falsy(signedUrl)
 })

--- a/roundabout/utils.js
+++ b/roundabout/utils.js
@@ -3,6 +3,8 @@ export const MAX_EXPIRES_IN = 3 * 24 * 60 * 60 // 7 days in seconds
 export const MIN_EXPIRES_IN = 1
 export const DEFAULT_EXPIRES_IN = 3 * 24 * 60 * 60 // 3 days in seconds by default
 
+export const VALID_BUCKETS = ['dagcargo']
+
 /**
  * @param {import('aws-lambda').APIGatewayProxyEventPathParameters | undefined} queryStringParameters
  */
@@ -15,6 +17,10 @@ export function parseQueryStringParameters (queryStringParameters) {
   }
 
   const bucketName = queryStringParameters?.bucket
+
+  if (bucketName && !VALID_BUCKETS.includes(bucketName)) {
+    throw new Error(`Bad requested with not acceptable bucket: ${bucketName}`)
+  }
 
   return {
     expiresIn,

--- a/roundabout/utils.js
+++ b/roundabout/utils.js
@@ -14,8 +14,11 @@ export function parseQueryStringParameters (queryStringParameters) {
     throw new Error(`Bad request with not acceptable expires parameter: ${queryStringParameters?.expires}`)
   }
 
+  const bucketName = queryStringParameters?.bucket
+
   return {
-    expiresIn
+    expiresIn,
+    bucketName
   }
 }
 

--- a/stacks/roundabout-stack.js
+++ b/stacks/roundabout-stack.js
@@ -34,6 +34,8 @@ export function RoundaboutStack({ stack, app }) {
     routes: {
       'GET /{cid}':       'functions/redirect.handler',
       'HEAD /{cid}':      'functions/redirect.handler',
+      'GET /raw/{key}':   'functions/redirect.rawHandler',
+      'HEAD /raw/{key}':   'functions/redirect.rawHandler',
     },
     accessLog: {
       format:'{"requestTime":"$context.requestTime","requestId":"$context.requestId","httpMethod":"$context.httpMethod","path":"$context.path","routeKey":"$context.routeKey","status":$context.status,"responseLatency":$context.responseLatency,"integrationRequestId":"$context.integration.requestId","integrationStatus":"$context.integration.status","integrationLatency":"$context.integration.latency","integrationServiceStatus":"$context.integration.integrationStatus","ip":"$context.identity.sourceIp","userAgent":"$context.identity.userAgent"}'

--- a/stacks/roundabout-stack.js
+++ b/stacks/roundabout-stack.js
@@ -34,8 +34,8 @@ export function RoundaboutStack({ stack, app }) {
     routes: {
       'GET /{cid}':       'functions/redirect.handler',
       'HEAD /{cid}':      'functions/redirect.handler',
-      'GET /raw/{key}':   'functions/redirect.rawHandler',
-      'HEAD /raw/{key}':   'functions/redirect.rawHandler',
+      'GET /key/{key}':   'functions/redirect.keyHandler',
+      'HEAD /key/{key}':   'functions/redirect.keyHandler',
     },
     accessLog: {
       format:'{"requestTime":"$context.requestTime","requestId":"$context.requestId","httpMethod":"$context.httpMethod","path":"$context.path","routeKey":"$context.routeKey","status":$context.status,"responseLatency":$context.responseLatency,"integrationRequestId":"$context.integration.requestId","integrationStatus":"$context.integration.status","integrationLatency":"$context.integration.latency","integrationServiceStatus":"$context.integration.integrationStatus","ip":"$context.identity.sourceIp","userAgent":"$context.identity.userAgent"}'

--- a/test/helpers/context.js
+++ b/test/helpers/context.js
@@ -16,9 +16,16 @@ dotenv.config({
  * @property {string} apiEndpoint
  * @property {Dynamo} metricsDynamo
  * @property {Dynamo} spaceMetricsDynamo
+ * 
+ * @typedef {object} RoundaboutContext
+ * @property {string} roundaboutEndpoint
  *
  * @typedef {import("ava").TestFn<Awaited<Context>>} TestContextFn
+ * @typedef {import("ava").TestFn<Awaited<RoundaboutContext>>} TestRoundaboutContextFn
  */
 
 // eslint-disable-next-line unicorn/prefer-export-from
 export const test  = /** @type {TestContextFn} */ (anyTest)
+
+// eslint-disable-next-line unicorn/prefer-export-from
+export const testRoundabout  = /** @type {TestRoundaboutContextFn} */ (anyTest)

--- a/test/helpers/deployment.js
+++ b/test/helpers/deployment.js
@@ -42,6 +42,20 @@ export const getApiEndpoint = () => {
   return testEnv[`${getStackName()}-${id}`].ApiEndpoint
 }
 
+export const getRoundaboutEndpoint = () => {
+  // CI/CD deployment
+  if (process.env.SEED_APP_NAME) {
+    return `https://${stage}.roundabout.web3.storage`
+  }
+
+  const require = createRequire(import.meta.url)
+  const testEnv = require('../../.test-env.json')
+
+  // Get Roundabout API endpoint
+  const id = 'RoundaboutStack'
+  return testEnv[`${getStackName()}-${id}`].ApiEndpoint
+}
+
 export const getSatnavBucketInfo = () => {
   // CI/CD deployment
   if (process.env.SEED_APP_NAME) {

--- a/test/roundabout.test.js
+++ b/test/roundabout.test.js
@@ -26,11 +26,11 @@ test('HEAD /{cid}', async t => {
   t.truthy(response.headers.get('location'))
 })
 
-test('HEAD /raw/{key}', async t => {
+test('HEAD /key/{key}', async t => {
   const key = '0000c19bd9cd7fa9c532eba81428eda0_baga6ea4seaqpohse35l4xucs5mtabgewpp4mgtle7yym7em6ouvhgjb7wc2pcmq.car'
   const bucketName = 'dagcargo'
   const response = await fetch(
-    `${t.context.roundaboutEndpoint}/raw/${key}?bucket=${bucketName}`,
+    `${t.context.roundaboutEndpoint}/key/${key}?bucket=${bucketName}`,
     {
       method: 'GET',
       redirect: 'manual'

--- a/test/roundabout.test.js
+++ b/test/roundabout.test.js
@@ -27,8 +27,9 @@ test('HEAD /{cid}', async t => {
 
 test('HEAD /raw/{key}', async t => {
   const key = '0000c19bd9cd7fa9c532eba81428eda0_baga6ea4seaqpohse35l4xucs5mtabgewpp4mgtle7yym7em6ouvhgjb7wc2pcmq.car'
+  const bucketName = 'dagcargo'
   const response = await fetch(
-    `${t.context.roundaboutEndpoint}/raw/${key}`,
+    `${t.context.roundaboutEndpoint}/raw/${key}?bucket=${bucketName}`,
     {
       method: 'HEAD'
     }

--- a/test/roundabout.test.js
+++ b/test/roundabout.test.js
@@ -1,0 +1,38 @@
+import { testRoundabout as test } from './helpers/context.js'
+
+import { fetch } from '@web-std/fetch'
+
+import {
+  getRoundaboutEndpoint
+} from './helpers/deployment.js'
+
+test.before(t => {
+  t.context = {
+    roundaboutEndpoint: getRoundaboutEndpoint(),
+  }
+})
+
+const carparkCid = 'bagbaiera223xmiutg62dsthdyd6kqgsft25knslnlaxxvwe6nc4zrwezezeq'
+
+test('HEAD /{cid}', async t => {
+  const response = await fetch(
+    `${t.context.roundaboutEndpoint}/${carparkCid}`,
+    {
+      method: 'HEAD'
+    }
+  )
+  t.is(response.status, 302)
+  t.truthy(response.headers.get('location'))
+})
+
+test('HEAD /raw/{key}', async t => {
+  const key = '0000c19bd9cd7fa9c532eba81428eda0_baga6ea4seaqpohse35l4xucs5mtabgewpp4mgtle7yym7em6ouvhgjb7wc2pcmq.car'
+  const response = await fetch(
+    `${t.context.roundaboutEndpoint}/raw/${key}`,
+    {
+      method: 'HEAD'
+    }
+  )
+  t.is(response.status, 302)
+  t.truthy(response.headers.get('location'))
+})

--- a/test/roundabout.test.js
+++ b/test/roundabout.test.js
@@ -18,7 +18,8 @@ test('HEAD /{cid}', async t => {
   const response = await fetch(
     `${t.context.roundaboutEndpoint}/${carparkCid}`,
     {
-      method: 'HEAD'
+      method: 'GET',
+      redirect: 'manual'
     }
   )
   t.is(response.status, 302)
@@ -31,7 +32,8 @@ test('HEAD /raw/{key}', async t => {
   const response = await fetch(
     `${t.context.roundaboutEndpoint}/raw/${key}?bucket=${bucketName}`,
     {
-      method: 'HEAD'
+      method: 'GET',
+      redirect: 'manual'
     }
   )
   t.is(response.status, 302)


### PR DESCRIPTION
There is also requirement to be able to create presigned URLs for [dagcargo bucket](https://dash.cloudflare.com/fffa4b4363a7e5250af8357087263b3a/r2/default/buckets/dagcargo). It does not have same format as carpark.

This PR adds a `GET /raw/{key}` endpoint to the API Gateway under roundabout. It enables to pass a raw key of a bucket, rather than a CID that is converted to the carpark key format. By default, it still picks `carpark` bucket if no bucket is provided.

Integration tests were added so that we can actually test the deployment, so that env vars and permissions are validated

Alternatively, we could consider not to be opinated about key key format and always receive a raw key. However, I think it makes sense to move into a way that we create key for carpark. There are a few advantages, like in the future if we have more buckets, bucket sharding or so on, we can easily abstract that logic within this API. Moreover, once we land w3filecoin spade integration, and deprecate old APIs, there will be no need for this format and we can consider to deprecate this new endpoint.

There is also option to be more explicit here, and also change `GET /{cid}` to be `GET /car/{cid}`, which would even allow in the future to get blocks for example, while being more inline with also getting a raw request.