### PR TITLE
fix: re-enable support for multiple providers

### DIFF
--- a/upload-api/config.js
+++ b/upload-api/config.js
@@ -9,11 +9,23 @@ import * as DID from '@ipld/dag-ucan/did'
  * @param {string} [config.UPLOAD_API_DID] - public DID for the upload service (did:key:... derived from PRIVATE_KEY if not set)
  * @returns {import('@ucanto/principal/ed25519').Signer.Signer}
  */
- export function getServiceSigner(config) {
+export function getServiceSigner(config) {
   const signer = ed25519.parse(config.PRIVATE_KEY)
   if (config.UPLOAD_API_DID) {
     const did = DID.parse(config.UPLOAD_API_DID).did()
     return signer.withDID(did)
   }
   return signer
+}
+
+/**
+ * Given a string, parse into provider service DIDs. 
+ * 
+ * @param {string} providersEnvVar 
+ * @return {import('@web3-storage/upload-api').ServiceDID[]}
+ */
+export function parseProviders(providersEnvVar) {
+  return /** @type {import('@web3-storage/upload-api').ServiceDID[]} */(
+    providersEnvVar.split(',').map(s => s.trim())
+  )
 }

--- a/upload-api/functions/ucan-invocation-router.js
+++ b/upload-api/functions/ucan-invocation-router.js
@@ -12,7 +12,7 @@ import { createTaskStore } from '../buckets/task-store.js'
 import { createWorkflowStore } from '../buckets/workflow-store.js'
 import { createStoreTable } from '../tables/store.js'
 import { createUploadTable } from '../tables/upload.js'
-import { getServiceSigner } from '../config.js'
+import { getServiceSigner, parseProviders } from '../config.js'
 import { createUcantoServer } from '../service.js'
 import { Config } from '@serverless-stack/node/config/index.js'
 import { CAR, Legacy, Codec } from '@ucanto/transport'
@@ -94,9 +94,9 @@ export async function ucanInvocationRouter(request) {
     WORKFLOW_BUCKET_NAME: workflowBucketName = '',
     UCAN_LOG_STREAM_NAME: streamName = '',
     POSTMARK_TOKEN: postmarkToken = '',
+    PROVIDERS: providers = '',
     // set for testing
     DYNAMO_DB_ENDPOINT: dbEndpoint,
-    ACCESS_SERVICE_DID: accessServiceDID = '',
     ACCESS_SERVICE_URL: accessServiceURL = '',
   } = process.env
 
@@ -123,10 +123,7 @@ export async function ucanInvocationRouter(request) {
   const consumerTable = createConsumerTable(AWS_REGION, consumerTableName, {
     endpoint: dbEndpoint
   });
-  const provisionsStorage = useProvisionStore(subscriptionTable, consumerTable, [
-    /** @type {import('@web3-storage/upload-api').ServiceDID} */
-    (accessServiceDID)
-  ])
+  const provisionsStorage = useProvisionStore(subscriptionTable, consumerTable, parseProviders(providers))
   const delegationsStorage = createDelegationsTable(AWS_REGION, delegationTableName, { bucket: delegationBucket, invocationBucket, workflowBucket })
 
   const server = createUcantoServer(serviceSigner, {

--- a/upload-api/functions/validate-email.jsx
+++ b/upload-api/functions/validate-email.jsx
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/serverless'
 import { authorize } from '@web3-storage/upload-api/validate'
 import { Config } from '@serverless-stack/node/config/index.js'
-import { getServiceSigner } from '../config.js'
+import { getServiceSigner, parseProviders } from '../config.js'
 import { Email } from '../email.js'
 import { createDelegationsTable } from '../tables/delegations.js'
 import { createDelegationsStore } from '../buckets/delegations-store.js'
@@ -63,7 +63,6 @@ export const preValidateEmail = Sentry.AWSLambda.wrapHandler(validateEmailGet)
 function createAuthorizeContext () {
   const {
     ACCESS_SERVICE_URL = '',
-    ACCESS_SERVICE_DID = '',
     AWS_REGION = '',
     DELEGATION_TABLE_NAME = '',
     R2_ENDPOINT = '',
@@ -76,6 +75,7 @@ function createAuthorizeContext () {
     SUBSCRIPTION_TABLE_NAME = '',
     CONSUMER_TABLE_NAME = '',
     UPLOAD_API_DID = '',
+    PROVIDERS = '',
     // set for testing
     DYNAMO_DB_ENDPOINT: dbEndpoint,
   } = process.env
@@ -98,10 +98,7 @@ function createAuthorizeContext () {
     email: new Email({ token: POSTMARK_TOKEN }),
     signer: getServiceSigner({ UPLOAD_API_DID, PRIVATE_KEY }),
     delegationsStorage: createDelegationsTable(AWS_REGION, DELEGATION_TABLE_NAME, { bucket: delegationBucket, invocationBucket, workflowBucket }),
-    provisionsStorage: useProvisionStore(subscriptionTable, consumerTable, [
-      /** @type {import('@web3-storage/upload-api').ServiceDID} */
-      (ACCESS_SERVICE_DID)
-    ]),
+    provisionsStorage: useProvisionStore(subscriptionTable, consumerTable, parseProviders(PROVIDERS)),
   }
 }
 


### PR DESCRIPTION
we lost this in the D1 migration work - go back to parsing the PROVIDERS env var and use the result as the list of supported providers