### PR TITLE
feat: index upload table by root CID

### DIFF
--- a/upload-api/tables/index.js
+++ b/upload-api/tables/index.js
@@ -25,6 +25,9 @@ export const uploadTableProps = {
   },
   // space + root must be unique to satisfy index constraint
   primaryIndex: { partitionKey: 'space', sortKey: 'root' },
+  globalIndexes: {
+    cid: { partitionKey: 'root', projection: ['space', 'insertedAt'] }
+  }
 }
 
 /** @type TableProps */


### PR DESCRIPTION
@dchoi27 needs to be able to figure out which space an upload went to, ie, he needs to be able to search space DIDs by upload CID

I'm not sure that we need `insertedAt` in here, but I do think it will be helpful to be able to see when a CID was uploaded to various spaces in the admin UI, so I'm including it in the projection. It would not be hard to convince me that we should leave it out...