### PR TITLE
fix: listen for any object_created event on carpark bucket

### DIFF
--- a/stacks/carpark-stack.js
+++ b/stacks/carpark-stack.js
@@ -76,7 +76,7 @@ export function CarparkStack({ stack, app }) {
   carparkBucket.addNotifications(stack, {
     newCarPut: {
       function: carparkPutEventConsumer,
-      events: ['object_created_put'],
+      events: ['object_created'],
     }
   })
 


### PR DESCRIPTION
we COPY cars into carpark from pickup as we first put them to a staging bucket before validating them.

listening for only the `object_created_put` event means copy events do not trigger indexing.

License: MIT