### PR TITLE
feat: add CID index to store table

### DIFF
--- a/upload-api/tables/index.js
+++ b/upload-api/tables/index.js
@@ -13,6 +13,9 @@ export const storeTableProps = {
   },
   // space + link must be unique to satisfy index constraint
   primaryIndex: { partitionKey: 'space', sortKey: 'link' },
+  globalIndexes: {
+    cid: { partitionKey: 'link', sortKey: 'space', projection: ['space', 'insertedAt'] }
+  }
 }
 
 /** @type TableProps */


### PR DESCRIPTION
We need to be able to figure out which space a CAR CID was added to.

Not adding anything more than the Dynamo index for now because:

a) we use the Dynamo console for blocking for now and b) we haven't designed the capabilities that will use this yet

this supercedes https://github.com/web3-storage/w3infra/pull/121/files