### PR TITLE
feat: add date index to uploads table

### DIFF
--- a/upload-api/tables/index.js
+++ b/upload-api/tables/index.js
@@ -26,7 +26,8 @@ export const uploadTableProps = {
   // space + root must be unique to satisfy index constraint
   primaryIndex: { partitionKey: 'space', sortKey: 'root' },
   globalIndexes: {
-    cid: { partitionKey: 'root', projection: ['space', 'insertedAt'] }
+    cid: { partitionKey: 'root', projection: ['space', 'insertedAt'] },
+    date: { partitionKey: 'insertedAt' , projection: ['root', 'space']}
   }
 }
 


### PR DESCRIPTION
The last piece of the blocking workflow that's not possible right now is being able to get a list of recent uploads. Add an index to the upload table to enable this.

I think this is the right thing to do for now while we figure out what kind of data warehousing setup we want, but we may want to consider removing this later.