### PR TITLE
fix: use ACCESS_SERVICE_URL in integration tests

### DIFF
--- a/test/helpers/up-client.js
+++ b/test/helpers/up-client.js
@@ -9,15 +9,17 @@ import { MailSlurp } from "mailslurp-client"
 /**
  * 
  * @param {string} email 
- * @param {string} uploadServiceUrl
+ * @param {string} accessServiceUrl
  */
-function getAuthLinkFromEmail (email, uploadServiceUrl) {
+function getAuthLinkFromEmail (email, accessServiceUrl) {
   // forgive me for I have s̵i̵n̴n̴e̵d̴ ̸a̸n̵d̷ ̷p̶a̵r̵s̵e̸d̷ Ȟ̷̞T̷̢̈́M̸̼̿L̴̎ͅ ̵̗̍ẅ̵̝́ï̸ͅt̴̬̅ḫ̸̔ ̵͚̔ŗ̵͊e̸͍͐g̶̜͒ė̷͖x̴̱̌
   // TODO we should update the email and add an ID to this element to make this more robust - tracked in https://github.com/web3-storage/w3infra/issues/208
   const link = email.match(/<a href="([^"]*)".*Verify email address/)[1]
-
+  if (!link.includes(process.env.ACCESS_SERVICE_URL)){
+    throw new Error('Could not find expected access service verification URL - does the value of ACCESS_SERVICE_URL in your local environment match the deployment you are testing?')
+  }
   // test auth services always link to the staging URL but we want to hit the service we're testing
-  return link.replace("https://staging.up.web3.storage", uploadServiceUrl)
+  return link.replace(process.env.ACCESS_SERVICE_URL, accessServiceUrl)
 }
 
 async function createMailSlurpInbox() {


### PR DESCRIPTION
rather than hardcoding https://staging.up.web3.storage. also add an error message to detect cases where the local ACCESS_SERVICE_URL