### PR TITLE
feat: add dynamo connector and rework tables

### DIFF
--- a/stacks/firehose-stack.js
+++ b/stacks/firehose-stack.js
@@ -129,6 +129,9 @@ export function UcanFirehoseStack ({ stack, app }) {
               {
                 parameterName: 'MetadataExtractionQuery',
                 // extract yyyy-MM-dd formatted current date from millisecond epoch timestamp "ts" using jq syntax
+                // extract type ('workflow' or 'receipt')
+                // extract the UCAN ability of the invocation to a key named "op" - this matches the latest UCAN spec https://github.com/ucan-wg/invocation/pull/21/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R208
+                //   we replace / with _ here since it will be used in the S3 bucket path and we a) don't want it to collide with the path separator and b) want it to be easy to refer to in queries
                 parameterValue: '{day: (.ts/1000) | strftime("%Y-%m-%d"), type: .type, op: (.value.att[0].can | sub("\/"; "_"))}',
               },
               {

--- a/stacks/firehose-stack.js
+++ b/stacks/firehose-stack.js
@@ -315,6 +315,8 @@ ORDER BY ts
   
   const dynamoAthenaLambdaName = getCdkNames('dynamo-athena', app.stage)
   const athenaDynamoConnector = new aws_sam.CfnApplication(stack, getCdkNames('athena-dynamo-connector', app.stage), {
+    // I got this ARN and version from the AWS admin UI after configuring the Athena Dynamo connector manually using these instructions:
+    // https://docs.aws.amazon.com/athena/latest/ug/connect-data-source-serverless-app-repo.html
     location: {
       applicationId: 'arn:aws:serverlessrepo:us-east-1:292517598671:applications/AthenaDynamoDBConnector',
       semanticVersion: '2023.38.1'

--- a/stacks/firehose-stack.js
+++ b/stacks/firehose-stack.js
@@ -175,6 +175,10 @@ export function UcanFirehoseStack ({ stack, app }) {
     }
   })
 
+  // creates a table that can be seen in the AWS Glue table browser at 
+  // https://console.aws.amazon.com/glue/home#/v2/data-catalog/tables
+  // and in the data browser in the Athena Query editor at
+  // https://console.aws.amazon.com/athena/home#/query-editor
   const receiptTableName = getCdkNames('ucan-receipt-table', app.stage)
   const receiptTable = new glue.CfnTable(stack, receiptTableName, {
     catalogId: Aws.ACCOUNT_ID,
@@ -223,6 +227,10 @@ export function UcanFirehoseStack ({ stack, app }) {
   })
   receiptTable.addDependsOn(glueDatabase)
 
+  // creates a table that can be seen in the AWS Glue table browser at 
+  // https://console.aws.amazon.com/glue/home#/v2/data-catalog/tables
+  // and in the data browser in the Athena Query editor at
+  // https://console.aws.amazon.com/athena/home#/query-editor
   const storeAddTableName = getCdkNames('store-add-table', app.stage)
   const storeAddTable = new glue.CfnTable(stack, storeAddTableName, {
     catalogId: Aws.ACCOUNT_ID,
@@ -268,6 +276,10 @@ export function UcanFirehoseStack ({ stack, app }) {
   })
   storeAddTable.addDependsOn(glueDatabase)
 
+  // creates a table that can be seen in the AWS Glue table browser at 
+  // https://console.aws.amazon.com/glue/home#/v2/data-catalog/tables
+  // and in the data browser in the Athena Query editor at
+  // https://console.aws.amazon.com/athena/home#/query-editor
   const uploadAddTableName = getCdkNames('upload-add-table', app.stage)
   const uploadAddTable = new glue.CfnTable(stack, uploadAddTableName, {
     catalogId: Aws.ACCOUNT_ID,
@@ -313,6 +325,10 @@ export function UcanFirehoseStack ({ stack, app }) {
   })
   uploadAddTable.addDependsOn(glueDatabase)
 
+  // creates a table that can be seen in the AWS Glue table browser at 
+  // https://console.aws.amazon.com/glue/home#/v2/data-catalog/tables
+  // and in the data browser in the Athena Query editor at
+  // https://console.aws.amazon.com/athena/home#/query-editor
   const providerAddTableName = getCdkNames('provider-add-table', app.stage)
   const providerAddTable = new glue.CfnTable(stack, providerAddTableName, {
     catalogId: Aws.ACCOUNT_ID,
@@ -370,6 +386,11 @@ export function UcanFirehoseStack ({ stack, app }) {
       }
     }
   })
+
+  // create a workgroup to keep queries organized by `app.stage`
+  // to use the queries below, Athena users must select the appropriate 
+  // workspace in the query editor at:
+  // https://console.aws.amazon.com/athena/home#/query-editor
   const workgroupName = getCdkNames('w3up', app.stage)
   const workgroup = new athena.CfnWorkGroup(stack, workgroupName, {
     name: workgroupName,
@@ -380,6 +401,9 @@ export function UcanFirehoseStack ({ stack, app }) {
     }
   })
 
+  // create a query that can be executed by going to 
+  // https://console.aws.amazon.com/athena/home#/query-editor/saved-queries
+  // and selecting the appropriate Workgroup from the dropdown in the upper right
   const inputOutputQueryName = getCdkNames('input-output-query', app.stage)
   const inputOutputQuery = new athena.CfnNamedQuery(stack, inputOutputQueryName, {
     name: "Inputs and Outputs, last 24 hours",
@@ -396,6 +420,9 @@ WHERE day >= (CURRENT_DATE - INTERVAL '1' DAY)
   inputOutputQuery.addDependsOn(workgroup)
   inputOutputQuery.addDependsOn(receiptTable)
 
+  // create a query that can be executed by going to 
+  // https://console.aws.amazon.com/athena/home#/query-editor/saved-queries
+  // and selecting the appropriate Workgroup from the dropdown in the upper right
   const dataStoredQueryName = getCdkNames('data-stored-query', app.stage)
   const dataStoredQuery = new athena.CfnNamedQuery(stack, dataStoredQueryName, {
     name: "Data stored by space, past 7 days",
@@ -414,6 +441,9 @@ GROUP BY value.att[1]."with"
   dataStoredQuery.addDependsOn(workgroup)
   dataStoredQuery.addDependsOn(storeAddTable)
 
+  // create a query that can be executed by going to 
+  // https://console.aws.amazon.com/athena/home#/query-editor/saved-queries
+  // and selecting the appropriate Workgroup from the dropdown in the upper right
   const storesBySpaceQueryName = getCdkNames('stores-by-space-query', app.stage)
   const storesBySpaceQuery = new athena.CfnNamedQuery(stack, storesBySpaceQueryName, {
     name: "Stores, past 7 days",
@@ -454,6 +484,9 @@ stores_by_account AS (
   storesBySpaceQuery.addDependsOn(providerAddTable)
   storesBySpaceQuery.addDependsOn(storeAddTable)
 
+  // create a query that can be executed by going to 
+  // https://console.aws.amazon.com/athena/home#/query-editor/saved-queries
+  // and selecting the appropriate Workgroup from the dropdown in the upper right
   const uploadsQueryName = getCdkNames('uploads-query', app.stage)
   const uploadsQuery = new athena.CfnNamedQuery(stack, uploadsQueryName, {
     name: "Uploads, past 7 days",
@@ -494,6 +527,9 @@ uploads_by_account AS (
   uploadsQuery.addDependsOn(providerAddTable)
   uploadsQuery.addDependsOn(uploadAddTable)
 
+  // create a query that can be executed by going to 
+  // https://console.aws.amazon.com/athena/home#/query-editor/saved-queries
+  // and selecting the appropriate Workgroup from the dropdown in the upper right
   const uploadVolumeSizeQueryName = getCdkNames('upload-volume-size-query', app.stage)
   const uploadVolumeSizeQuery = new athena.CfnNamedQuery(stack, uploadVolumeSizeQueryName, {
     name: "Users with highest upload volume (by size), past day",
@@ -532,6 +568,9 @@ stores_by_account AS (
   uploadVolumeSizeQuery.addDependsOn(providerAddTable)
   uploadVolumeSizeQuery.addDependsOn(storeAddTable)
 
+  // create a query that can be executed by going to
+  // https://console.aws.amazon.com/athena/home#/query-editor/saved-queries
+  // and selecting the appropriate Workgroup from the dropdown in the upper right
   const uploadVolumeCountQueryName = getCdkNames('upload-volume-count-query', app.stage)
   const uploadVolumeCountQuery = new athena.CfnNamedQuery(stack, uploadVolumeCountQueryName, {
     name: "Users with highest upload volume (by count), past day",
@@ -571,6 +610,9 @@ uploads_by_account AS (
   uploadVolumeCountQuery.addDependsOn(providerAddTable)
   uploadVolumeCountQuery.addDependsOn(storeAddTable)
 
+  // create a query that can be executed by going to
+  // https://console.aws.amazon.com/athena/home#/query-editor/saved-queries
+  // and selecting the appropriate Workgroup from the dropdown in the upper right
   const uploadsBySpaceAndSizeQueryName = getCdkNames('uploads-by-space-and-size', app.stage)
   const uploadsBySpaceAndSizeQuery = new athena.CfnNamedQuery(stack, uploadsBySpaceAndSizeQueryName, {
     name: "Uploads by space and size, last 2 days",
@@ -655,6 +697,8 @@ ORDER BY upload_ts DESC
     }
   })
 
+  // creates an Athena data source that will enable Athena to query our dynamo tables:
+  // https://console.aws.amazon.com/athena/home#/data-sources
   const dynamoDataCatalogName = getCdkNames('dynamo-data-catalog', app.stage)
   const dynamoDataCatalogDatabaseName = getCdkNames('dynamo', app.stage)
   const dynamoDataCatalog = new athena.CfnDataCatalog(stack, dynamoDataCatalogName, {
@@ -668,6 +712,9 @@ ORDER BY upload_ts DESC
 
   // queries that depend on the Athena Dynamo connector
 
+  // create a query that can be executed by going to
+  // https://console.aws.amazon.com/athena/home#/query-editor/saved-queries
+  // and selecting the appropriate Workgroup from the dropdown in the upper right
   const spacesByAccountQueryName = getCdkNames('spaces-by-account-query', app.stage)
   const spacesByAccountQuery = new athena.CfnNamedQuery(stack, spacesByAccountQueryName, {
     name: "Dynamo: spaces by account",
@@ -685,6 +732,9 @@ FROM "${dynamoDataCatalogDatabaseName}"."default"."${app.stage}-w3infra-subscrip
   spacesByAccountQuery.addDependsOn(dynamoDataCatalog)
   spacesByAccountQuery.addDependsOn(workgroup)
 
+  // create a query that can be executed by going to
+  // https://console.aws.amazon.com/athena/home#/query-editor/saved-queries
+  // and selecting the appropriate Workgroup from the dropdown in the upper right
   const uploadsByAccountQueryName = getCdkNames('uploads-by-account-query', app.stage)
   const uploadsByAccountQuery = new athena.CfnNamedQuery(stack, uploadsByAccountQueryName, {
     name: "Dynamo: uploads by account",

--- a/stacks/firehose-stack.js
+++ b/stacks/firehose-stack.js
@@ -293,7 +293,7 @@ export function UcanFirehoseStack ({ stack, app }) {
           { name: 'carcid', type: 'string' },
           // STRUCT here refers to the Apache Hive STRUCT datatype - see https://aws.amazon.com/blogs/big-data/create-tables-in-amazon-athena-from-nested-json-and-mappings-using-jsonserde/
           { name: 'value', type: 'STRUCT<att:ARRAY<STRUCT<can:STRING,with:STRING,nb:STRUCT<root:STRUCT<_cid_slash:STRING>,shards:ARRAY<STRUCT<_cid_slash:STRING>>>>>,iss:STRING,aud:STRING>' },
-          { name: "out", type: "STRUCT<error:STRUCT<name:STRING>,ok:STRUCT<root:STRUCT<_cid_slash:STRING>>>" },
+          { name: "out", type: "STRUCT<error:STRUCT<name:STRING>,ok:STRUCT<root:STRUCT<_cid_slash:STRING>,shards:ARRAY<STRUCT<_cid_slash:STRING>>>>" },
           { name: "ts", type: "timestamp" }
         ],
         inputFormat: 'org.apache.hadoop.mapred.TextInputFormat',

--- a/stacks/firehose-stack.js
+++ b/stacks/firehose-stack.js
@@ -218,7 +218,7 @@ export function UcanFirehoseStack ({ stack, app }) {
   const inputOutputQueryName = getCdkNames('input-output-query', app.stage)
   const inputOutputQuery = new athena.CfnNamedQuery(stack, inputOutputQueryName, {
     name: "Inputs and Outputs, last 24 hours",
-    description: "(w3up preloaded)",
+    description: `${app.stage} w3up preload`,
     database: databaseName,
     queryString: `SELECT 
   value.att[1] as "in",
@@ -233,7 +233,7 @@ WHERE type = 'receipt'
   const dataStoredQueryName = getCdkNames('data-stored-query', app.stage)
   const dataStoredQuery = new athena.CfnNamedQuery(stack, dataStoredQueryName, {
     name: "Data stored by space, last week",
-    description: "(w3up preloaded)",
+    description: `${app.stage} w3up preload`,
     database: databaseName,
     queryString: `SELECT
   SUM(value.att[1].nb.size) AS size,
@@ -251,7 +251,7 @@ GROUP BY value.att[1]."with"
   const storesBySpaceQueryName = getCdkNames('stores-by-space-query', app.stage)
   const storesBySpaceQuery = new athena.CfnNamedQuery(stack, storesBySpaceQueryName, {
     name: "Stores by space, last week",
-    description: "(w3up preloaded)",
+    description: `${app.stage} w3up preload`,
     database: databaseName,
     queryString: `SELECT
   value.att[1].nb.size AS size,
@@ -269,7 +269,7 @@ WHERE value.att[1].can='store/add'
   const uploadsQueryName = getCdkNames('uploads-query', app.stage)
   const uploadsQuery = new athena.CfnNamedQuery(stack, uploadsQueryName, {
     name: "Uploads, last week",
-    description: "(w3up preloaded)",
+    description: `${app.stage} w3up preload`,
     database: databaseName,
     queryString: `SELECT
   value.att[1].nb.root._cid_slash AS cid,
@@ -328,7 +328,7 @@ ORDER BY ts
   const spacesByAccountQueryName = getCdkNames('spaces-by-account-query', app.stage)
   const spacesByAccountQuery = new athena.CfnNamedQuery(stack, spacesByAccountQueryName, {
     name: "Spaces by account",
-    description: "(w3up preloaded)",
+    description: `${app.stage} w3up preload`,
     database: databaseName,
     queryString: `SELECT 
   customer as account,
@@ -343,7 +343,7 @@ FROM "${dynamoDataCatalogDatabaseName}"."default"."${app.stage}-w3infra-subscrip
   const uploadsByAccountQueryName = getCdkNames('uploads-by-account-query', app.stage)
   const uploadsByAccountQuery = new athena.CfnNamedQuery(stack, uploadsByAccountQueryName, {
     name: "Uploads by account",
-    description: "(w3up preloaded)",
+    description: `${app.stage} w3up preload`,
     database: databaseName,
     queryString: `WITH 
 spaces AS (

--- a/stacks/firehose-stack.js
+++ b/stacks/firehose-stack.js
@@ -132,7 +132,7 @@ export function UcanFirehoseStack ({ stack, app }) {
                 // extract type ('workflow' or 'receipt')
                 // extract the UCAN ability of the invocation to a key named "op" - this matches the latest UCAN spec https://github.com/ucan-wg/invocation/pull/21/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R208
                 //   we replace / with _ here since it will be used in the S3 bucket path and we a) don't want it to collide with the path separator and b) want it to be easy to refer to in queries
-                parameterValue: '{day: (.ts/1000) | strftime("%Y-%m-%d"), type: .type, op: (.value.att[0].can | sub("\/"; "_"))}',
+                parameterValue: '{day: (.ts/1000) | strftime("%Y-%m-%d"), type: .type, op: (.value.att[0].can | gsub("\/"; "_"))}',
               },
               {
                 parameterName: 'JsonParsingEngine',

--- a/stacks/firehose-stack.js
+++ b/stacks/firehose-stack.js
@@ -297,6 +297,9 @@ ORDER BY ts
 
   // configure the Athena Dynamo connector
 
+  // Considering Lambda functions limits response sizes, responses larger than the threshold 
+  // spill into an Amazon S3 location that you specify when you create your Lambda function. 
+  // Athena reads these responses from Amazon S3 directly.
   const athenaDynamoSpillBucket = new Bucket(stack, 'athena-dynamo-spill', {
     cors: true,
     cdk: {


### PR DESCRIPTION
Plus example query joining dynamo to ucan logs.

Additionally,  after chatting with @dchoi27 this morning, two major optimizations:
 1. partition by `type` and rework the ucan table to only look at "receipts" - everything in "workflows" shows up in receipts so this reduces the amount of data scanned by ~50%
 2. partition by `op` to allow us to create tables that only query a specific operation (ie, `store/add` or `provider/add`) - this lets us add operation-specific schemas with much less clutter in result types
 
Using these optimizations, I've added standalone tables for `store/add`, `upload/add` and `provider/add` UCANs. I will rework the saved queries to use them next.