### PR TITLE
feat: add two more capability tables for Athena

### DIFF
--- a/stacks/firehose-stack.js
+++ b/stacks/firehose-stack.js
@@ -9,7 +9,6 @@ import {
   aws_athena as athena,
   aws_sam as sam
 } from 'aws-cdk-lib'
-import { Access, Provider, Space, Store, Upload, Consumer, Customer, RateLimit, Subscription, Filecoin, Admin, UCAN } from '@web3-storage/capabilities'
 
 import { UcanInvocationStack } from './ucan-invocation-stack.js'
 


### PR DESCRIPTION
Add two more capability tables to Glue so Athena can query them.

I'd like to start doing this in an automated way at some point, but that doesn't feel high priority enough for the moment so I've filed an issue here:

https://github.com/web3-storage/w3infra/issues/243