### PR TITLE
feat: allow customers to create more than one space

### DIFF
--- a/test/helpers/up-client.js
+++ b/test/helpers/up-client.js
@@ -22,7 +22,7 @@ function getAuthLinkFromEmail (email, accessServiceUrl) {
   return link.replace(process.env.ACCESS_SERVICE_URL, accessServiceUrl)
 }
 
-async function createMailSlurpInbox() {
+export async function createMailSlurpInbox() {
   const apiKey = process.env.MAILSLURP_API_KEY
   const mailslurp = new MailSlurp({ apiKey })
   const inbox = await mailslurp.inboxController.createInbox({})
@@ -46,7 +46,7 @@ export async function createNewClient(uploadServiceUrl) {
 
 export async function setupNewClient (uploadServiceUrl, options = {}) {
   // create an inbox
-  const { mailslurp, id: inboxId, email } = await createMailSlurpInbox()
+  const { mailslurp, id: inboxId, email } = options.inbox || await createMailSlurpInbox()
   const client = await createNewClient(uploadServiceUrl)
 
   const timeoutMs = process.env.MAILSLURP_TIMEOUT ? parseInt(process.env.MAILSLURP_TIMEOUT) : 60_000

--- a/upload-api/stores/provisions.js
+++ b/upload-api/stores/provisions.js
@@ -4,14 +4,14 @@ import { CBOR, Failure } from '@ucanto/server'
 
 /**
  * Create a subscription ID for a given provision. Currently 
- * uses a CID generated from `customer` and `consumer` which ensures each customer
- * will get at most one subscription per space.
+ * uses a CID generated from `consumer` which ensures a space
+ * can be provisioned at most once.
  * 
  * @param {import('@web3-storage/upload-api').Provision} item 
  * @returns string
  */
 export const createProvisionSubscriptionId = async ({ customer, consumer }) =>
-  (await CBOR.write({ customer, consumer })).cid.toString()
+  (await CBOR.write({ consumer })).cid.toString()
 
 /**
  * @param {import('../types').SubscriptionTable} subscriptionTable

--- a/upload-api/stores/provisions.js
+++ b/upload-api/stores/provisions.js
@@ -4,16 +4,14 @@ import { CBOR, Failure } from '@ucanto/server'
 
 /**
  * Create a subscription ID for a given provision. Currently 
- * uses the CID of `customer` which ensures each customer
- * will get at most one subscription. This can be relaxed (ie,
- * by deriving subscription ID from customer AND consumer) in the future
- * or by other providers for flexibility.
+ * uses a CID generated from `customer` and `consumer` which ensures each customer
+ * will get at most one subscription per space.
  * 
  * @param {import('@web3-storage/upload-api').Provision} item 
  * @returns string
  */
-export const createProvisionSubscriptionId = async ({ customer }) =>
-  (await CBOR.write({ customer })).cid.toString()
+export const createProvisionSubscriptionId = async ({ customer, consumer }) =>
+  (await CBOR.write({ customer, consumer })).cid.toString()
 
 /**
  * @param {import('../types').SubscriptionTable} subscriptionTable


### PR DESCRIPTION
this is just a matter of changing how we generate subscription IDs. they are now generated from customer AND consumer, which means they will be unique for a given customer/consumer pair - in other words, a given customer will only be able to provision a given space one time.