### PR TITLE
fix: ucan message types and parser

### DIFF
--- a/billing/functions/ucan-stream.js
+++ b/billing/functions/ucan-stream.js
@@ -63,11 +63,24 @@ const parseUcanStreamEvent = event => {
   const batch = event.Records.map(r => fromString(r.kinesis.data, 'base64'))
   return batch.map(b => {
     const json = JSON.parse(toString(b, 'utf8'))
-    return {
-      ...json,
-      carCid: Link.parse(json.carCid),
-      invocationCid: Link.parse(json.invocationCid),
-      ts: new Date(json.ts)
+    if (json.type === 'receipt') {
+      return {
+        type: 'receipt',
+        value: { ...json.value, cid: Link.parse(json.value.cid) },
+        carCid: Link.parse(json.carCid),
+        invocationCid: Link.parse(json.invocationCid),
+        out: json.out,
+        ts: new Date(json.ts)
+      }
+    } else if (json.type === 'workflow') {
+      return {
+        type: 'workflow',
+        value: { ...json.value, cid: Link.parse(json.value.cid) },
+        carCid: Link.parse(json.carCid),
+        ts: new Date(json.ts)
+      }
+    } else {
+      throw new Error(`unknown message type: ${json.type}`)
     }
   })
 }

--- a/billing/lib/api.ts
+++ b/billing/lib/api.ts
@@ -210,7 +210,6 @@ export type SubscriptionStore =
 // TODO: replace `UcanInvocation` type in `ucan-invocation/types.ts` with this?
 export interface UcanMessage<C extends Capabilities = Capabilities> {
   carCid: Link
-  invocationCid: Link
   value: UcanMessageValue<C>
   ts: Date
 }
@@ -220,6 +219,7 @@ export interface UcanMessageValue<C extends Capabilities = Capabilities> {
   aud: DID,
   iss?: DID,
   prf?: Array<LinkJSON<Link>>
+  cid: Link
 }
 
 export interface UcanReceiptMessage<
@@ -227,6 +227,7 @@ export interface UcanReceiptMessage<
   R extends Result = Result
 > extends UcanMessage<C> {
   type: 'receipt'
+  invocationCid: Link
   out: R
 }
 

--- a/billing/test/lib/ucan-stream.js
+++ b/billing/test/lib/ucan-stream.js
@@ -13,20 +13,20 @@ export const test = {
     const invocations = [{
       type: 'workflow',
       carCid: randomLink(),
-      invocationCid: randomLink(),
       value: {
         att: [{
           with: await randomDID(),
           can: 'store/list'
         }],
-        aud: await randomDID()
+        aud: await randomDID(),
+        cid: randomLink()
       },
       ts: new Date()
     }]
 
     const shard = randomLink()
 
-    /** @type {import('../../lib/api.js').UcanStreamMessage[]} */
+    /** @type {import('../../lib/api.js').UcanReceiptMessage[]} */
     const receipts = [{
       type: 'receipt',
       carCid: randomLink(),
@@ -40,7 +40,8 @@ export const test = {
             size: 138
           }
         }],
-        aud: await randomDID()
+        aud: await randomDID(),
+        cid: randomLink()
       },
       out: { ok: { status: 'upload' } },
       ts: new Date()
@@ -54,7 +55,8 @@ export const test = {
           can: 'store/remove',
           nb: { link: shard }
         }],
-        aud: await randomDID()
+        aud: await randomDID(),
+        cid: randomLink()
       },
       out: { ok: { size: 138 } },
       ts: new Date()
@@ -99,7 +101,8 @@ export const test = {
             size: 138
           }
         }],
-        aud: consumer.provider
+        aud: consumer.provider,
+        cid: randomLink()
       },
       out: { ok: { status: 'upload' } },
       ts: new Date(from.getTime() + 1)
@@ -116,7 +119,8 @@ export const test = {
             size: 1138
           }
         }],
-        aud: consumer.provider
+        aud: consumer.provider,
+        cid: randomLink()
       },
       out: { ok: { status: 'upload' } },
       ts: new Date(from.getTime() + 2)

--- a/package-lock.json
+++ b/package-lock.json
@@ -20878,7 +20878,7 @@
         "entail": "^2.1.1",
         "multiformats": "^12.1.2",
         "p-retry": "^6.1.0",
-        "stripe": "*",
+        "stripe": "^14.1.0",
         "testcontainers": "^10.2.1",
         "uint8arrays": "^4.0.6"
       },


### PR DESCRIPTION
Turns out `invocationCid` is only set on receipt messages.