### PR TITLE
fix: allow optional fields

### DIFF
--- a/billing/data/consumer.js
+++ b/billing/data/consumer.js
@@ -16,9 +16,9 @@ const schema = Schema.struct({
   consumer: Schema.did(),
   provider: Schema.did({ method: 'web' }),
   subscription: Schema.text(),
-  cause: Schema.link({ version: 1 }),
+  cause: Schema.link({ version: 1 }).optional(),
   insertedAt: Schema.date(),
-  updatedAt: Schema.date()
+  updatedAt: Schema.date().optional()
 })
 
 /** @type {import('../lib/api').Validator<Consumer>} */
@@ -32,9 +32,9 @@ export const encode = input => {
         consumer: input.consumer,
         provider: input.provider,
         subscription: input.subscription,
-        cause: input.cause.toString(),
+        cause: input.cause ? input.cause.toString() : undefined,
         insertedAt: input.insertedAt.toISOString(),
-        updatedAt: input.updatedAt.toISOString()
+        updatedAt: input.updatedAt ? input.updatedAt.toISOString() : undefined
       }
     }
   } catch (/** @type {any} */ err) {
@@ -54,7 +54,7 @@ export const decode = input => {
         subscription: /** @type {string} */ (input.subscription),
         cause: Link.parse(/** @type {string} */ (input.cause)),
         insertedAt: new Date(input.insertedAt),
-        updatedAt: new Date(input.updatedAt)
+        updatedAt: input.updatedAt ? new Date(input.updatedAt) : undefined
       }
     }
   } catch (/** @type {any} */ err) {

--- a/billing/data/customer.js
+++ b/billing/data/customer.js
@@ -15,7 +15,7 @@ const schema = Schema.struct({
   product: Schema.text(),
   cause: Schema.link({ version: 1 }),
   insertedAt: Schema.date(),
-  updatedAt: Schema.date()
+  updatedAt: Schema.date().optional()
 })
 
 /** @type {import('../lib/api').Validator<Customer>} */
@@ -31,7 +31,7 @@ export const encode = input => {
         account: input.account,
         product: input.product,
         insertedAt: input.insertedAt.toISOString(),
-        updatedAt: input.updatedAt.toISOString()
+        updatedAt: input.updatedAt ? input.updatedAt.toISOString() : undefined
       }
     }
   } catch (/** @type {any} */ err) {
@@ -54,7 +54,7 @@ export const decode = input => {
         account: Schema.uri({ protocol: 'stripe:' }).from(input.account),
         product: /** @type {string} */ (input.product),
         insertedAt: new Date(input.insertedAt),
-        updatedAt: new Date(input.updatedAt)
+        updatedAt: input.updatedAt ? new Date(input.updatedAt) : undefined
       }
     }
   } catch (/** @type {any} */ err) {

--- a/billing/data/subscription.js
+++ b/billing/data/subscription.js
@@ -16,9 +16,9 @@ const schema = Schema.struct({
   customer: Schema.did({ method: 'mailto' }),
   provider: Schema.did({ method: 'web' }),
   subscription: Schema.text(),
-  cause: Schema.link({ version: 1 }),
+  cause: Schema.link({ version: 1 }).optional(),
   insertedAt: Schema.date(),
-  updatedAt: Schema.date()
+  updatedAt: Schema.date().optional()
 })
 
 /** @type {import('../lib/api').Validator<Subscription>} */
@@ -32,9 +32,9 @@ export const encode = input => {
         customer: input.customer,
         provider: input.provider,
         subscription: input.subscription,
-        cause: input.cause.toString(),
+        cause: input.cause ? input.cause.toString() : undefined,
         insertedAt: input.insertedAt.toISOString(),
-        updatedAt: input.updatedAt.toISOString()
+        updatedAt: input.updatedAt ? input.updatedAt.toISOString() : undefined
       }
     }
   } catch (/** @type {any} */ err) {
@@ -60,9 +60,9 @@ export const decode = input => {
         customer: Schema.did({ method: 'mailto' }).from(input.customer),
         provider: Schema.did({ method: 'web' }).from(input.provider),
         subscription: /** @type {string} */ (input.subscription),
-        cause: Link.parse(/** @type {string} */ (input.cause)),
+        cause: input.cause ? Link.parse(/** @type {string} */ (input.cause)) : undefined,
         insertedAt: new Date(input.insertedAt),
-        updatedAt: new Date(input.updatedAt)
+        updatedAt: input.updatedAt ? new Date(input.updatedAt) : undefined
       }
     }
   } catch (/** @type {any} */ err) {
@@ -84,7 +84,7 @@ export const lister = {
           customer: Schema.did({ method: 'mailto' }).from(input.customer),
           provider: Schema.did({ method: 'web' }).from(input.provider),
           subscription: String(input.subscription),
-          cause: Link.parse(String(input.cause))
+          cause: input.cause ? Link.parse(String(input.cause)) : undefined
         }
       }
     } catch (/** @type {any} */ err) {

--- a/billing/lib/api.ts
+++ b/billing/lib/api.ts
@@ -86,7 +86,7 @@ export interface Customer {
   /** Time the record was added to the database. */
   insertedAt: Date
   /** Time the record was updated in the database. */
-  updatedAt: Date
+  updatedAt?: Date
 }
 
 export interface CustomerKey {
@@ -177,9 +177,10 @@ export interface Consumer {
   consumer: ConsumerDID
   provider: ProviderDID
   subscription: string
-  cause: Link
+  /** This became a required field after 2023-07-10T23:12:38.000Z. */
+  cause?: Link
   insertedAt: Date
-  updatedAt: Date
+  updatedAt?: Date
 }
 
 export interface ConsumerKey { subscription: string, provider: ProviderDID }
@@ -193,9 +194,10 @@ export interface Subscription {
   customer: CustomerDID
   provider: ProviderDID
   subscription: string
-  cause: Link
+  /** This became a required field after 2023-07-18T10:24:38.000Z. */
+  cause?: Link
   insertedAt: Date
-  updatedAt: Date
+  updatedAt?: Date
 }
 
 export interface SubscriptionKey { provider: ProviderDID, subscription: string }

--- a/billing/tables/client.js
+++ b/billing/tables/client.js
@@ -30,7 +30,7 @@ export const createStorePutterClient = (conf, context) => {
 
       const cmd = new PutItemCommand({
         TableName: context.tableName,
-        Item: marshall(encoding.ok)
+        Item: marshall(encoding.ok, { removeUndefinedValues: true })
       })
 
       try {


### PR DESCRIPTION
Some fields i.e. `cause` because required after a certain time so need to be marked optional in the types and expected to be `undefined` sometimes when encoding/decoding.

Other fields like `updatedAt` are explicitly only set when the record has been updated.