### PR TITLE
fix: piece digest function

### DIFF
--- a/filecoin/index.js
+++ b/filecoin/index.js
@@ -57,13 +57,18 @@ export async function computePieceCid({
   let piece
   try {
     const hasher = Hasher.create()
-    const digest = new Uint8Array(hasher.multihashByteLength())
 
     // @ts-expect-error aws Readable stream types are not good
     for await (const chunk of res.Body) {
       hasher.write(chunk)
     }
+
+    // ⚠️ Because digest size will dependen on the payload (padding)
+    // we have to determine number of bytes needed after we're done
+    // writing payload
+    const digest = new Uint8Array(hasher.multihashByteLength())
     hasher.digestInto(digest, 0, true)
+
     // There's no GC (yet) in WASM so you should free up
     // memory manually once you're done.
     hasher.free()


### PR DESCRIPTION
Fixes the issue with the way digest had been computed. Since digest size depends on padding which depends on payload size we can not know what it will be until we're done feeding payload.

Issue is fixed by allocating buffer only after we're done writing into hasher.