### PR TITLE
feat: let user select a plan when authorizing

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -38,3 +38,7 @@ SATNAV_BUCKET_NAME = ''
 MAILSLURP_API_KEY = ''
 MAILSLURP_TIMEOUT = '120000'
 
+# Stripe
+# these values are from the Stripe test environment
+STRIPE_PRICING_TABLE_ID = 'prctbl_1NzhdvF6A5ufQX5vKNZuRhie'
+STRIPE_PUBLISHABLE_KEY = 'pk_test_51LO87hF6A5ufQX5viNsPTbuErzfavdrEFoBuaJJPfoIhzQXdOUdefwL70YewaXA32ZrSRbK4U4fqebC7SVtyeNcz00qmgNgueC'

--- a/stacks/upload-api-stack.js
+++ b/stacks/upload-api-stack.js
@@ -98,6 +98,8 @@ export function UploadApiStack({ stack, app }) {
           R2_DELEGATION_BUCKET_NAME: process.env.R2_DELEGATION_BUCKET_NAME ?? '',
           R2_ENDPOINT: process.env.R2_ENDPOINT ?? '',
           UPLOAD_API_DID: process.env.UPLOAD_API_DID ?? '',
+          STRIPE_PRICING_TABLE_ID: process.env.STRIPE_PRICING_TABLE_ID ?? '',
+          STRIPE_PUBLISHABLE_KEY: process.env.STRIPE_PUBLISHABLE_KEY ?? '',
         },
         bind: [
           privateKey,

--- a/upload-api/html.jsx
+++ b/upload-api/html.jsx
@@ -1,4 +1,5 @@
 import { render } from 'preact-render-to-string'
+import { createElement } from 'preact'
 import { Response } from '@web-std/fetch'
 
 /**
@@ -16,6 +17,7 @@ export function buildDocument(body) {
   <title>w3up Email Validation</title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <script async src="https://js.stripe.com/v3/pricing-table.js"></script>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@acab/reset.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/dark.min.css">
   <style>
@@ -141,68 +143,84 @@ export const PendingValidateEmail = ({ autoApprove }) => (
  * @param {string} param0.ucan
  * @param {string} param0.email
  * @param {string} param0.audience
+ * @param {string} [param0.stripePricingTableId]
+ * @param {string} [param0.stripePublishableKey]
  * @param {string} [param0.qrcode]
  */
-export const ValidateEmail = ({ ucan, qrcode, email, audience }) => (
-  <div style={{ maxWidth: '640px', paddingTop: '50px', margin: '0 auto' }}>
-    <header style={{ textAlign: 'center' }}>
-      <img
-        src="https://bafybeib7zsc7ppyfuby72dz4cpjonql7zt3vetf3cu7rios7hovlgaoug4.ipfs.w3s.link/w3up-logo.png"
-        style={{ height: '80px', display: 'inline-block' }}
-      />
-      <h1 style={{ paddingTop: '20px' }}>Email Validated</h1>
-      <p style={{ paddingBottom: '30px', color: 'white' }}>
-        {email} was confirmed. You may close this window.
-      </p>
-    </header>
-    <div class="box" style={{ fontSize: '14px' }}>
-      <p>
-        If you have an existing non-w3up beta account with NFT.Storage or
-        web3.storage and register for the w3up beta version of the same product
-        (NFT.Storage or web3.storage) using the same email, then at the end of
-        the beta period, these accounts will be combined. Until the beta period
-        is over and this migration occurs, uploads to w3up will not appear in
-        your NFT.Storage or web3.storage account (and vice versa), even if you
-        register with the same email.
-      </p>
-      <p>
-        By registering with either the web3.storage or the NFT.Storage w3up
-        beta, you agree to the respective Terms of Service (
-        <a href="https://console.web3.storage/terms">web3.storage ToS</a>,{' '}
-        <a href="https://console.nft.storage/terms">NFT.Storage ToS</a>).
-      </p>
-    </div>
-    <details
-      style={{ maxWidth: '640px', overflow: 'overlay', textDecoration: 'none' }}
-    >
-      {' '}
-      <summary style={{ fontSize: '14px' }}>Auth details</summary>
-      <h5 style={{ marginBottom: 0 }}>Validation requested by</h5>
-      <pre>
-        <code>{audience}</code>
-      </pre>
-      {qrcode && (
-        <>
-          <h5>QR Code</h5>
-          <div
-            // eslint-disable-next-line react/no-danger
-            dangerouslySetInnerHTML={{
-              __html: qrcode,
-            }}
-            class="mcenter"
-            style={{
-              width: '300px',
-            }}
-          />
-        </>
+export const ValidateEmail = ({ ucan, qrcode, email, audience, stripePricingTableId, stripePublishableKey }) => {
+  const showPricingTable = stripePricingTableId && stripePublishableKey
+  return (
+    <div style={{ maxWidth: '640px', paddingTop: '50px', margin: '0 auto' }}>
+      <header style={{ textAlign: 'center' }}>
+        <img
+          src="https://bafybeib7zsc7ppyfuby72dz4cpjonql7zt3vetf3cu7rios7hovlgaoug4.ipfs.w3s.link/w3up-logo.png"
+          style={{ height: '80px', display: 'inline-block' }}
+        />
+        <h1 style={{ paddingTop: '20px' }}>Email Validated</h1>
+        <p style={{ paddingBottom: '30px', color: 'white' }}>
+          {email} was confirmed. You may close this window.
+        </p>
+      </header>
+      <div class="box" style={{ fontSize: '14px' }}>
+        <p>
+          If you have an existing non-w3up beta account with NFT.Storage or
+          web3.storage and register for the w3up beta version of the same product
+          (NFT.Storage or web3.storage) using the same email, then at the end of
+          the beta period, these accounts will be combined. Until the beta period
+          is over and this migration occurs, uploads to w3up will not appear in
+          your NFT.Storage or web3.storage account (and vice versa), even if you
+          register with the same email.
+        </p>
+        <p>
+          By registering with either the web3.storage or the NFT.Storage w3up
+          beta, you agree to the respective Terms of Service (
+          <a href="https://console.web3.storage/terms">web3.storage ToS</a>,{' '}
+          <a href="https://console.nft.storage/terms">NFT.Storage ToS</a>).
+        </p>
+      </div>
+      {showPricingTable && (
+        <div class="box" style={{ fontSize: '14px' }}>
+          <p>In order to upload data using web3.storage's instance of w3up, you will need to sign up for a billing plan:</p>
+          { // @ts-expect-error preact's types aren't happy with a string here, but it works fine
+            createElement('stripe-pricing-table', {
+              'pricing-table-id': stripePricingTableId,
+              'publishable-key': stripePublishableKey,
+              'customer-email': email,
+            }, '')}
+        </div>
       )}
-      <h5 style={{ marginBottom: 0, paddingTop: '8px' }}>UCAN</h5>
-      <pre>
-        <code>{ucan}</code>
-      </pre>
-    </details>
-  </div>
-)
+      <details
+        style={{ maxWidth: '640px', overflow: 'overlay', textDecoration: 'none' }}
+      >
+        {' '}
+        <summary style={{ fontSize: '14px' }}>Auth details</summary>
+        <h5 style={{ marginBottom: 0 }}>Validation requested by</h5>
+        <pre>
+          <code>{audience}</code>
+        </pre>
+        {qrcode && (
+          <>
+            <h5>QR Code</h5>
+            <div
+              // eslint-disable-next-line react/no-danger
+              dangerouslySetInnerHTML={{
+                __html: qrcode,
+              }}
+              class="mcenter"
+              style={{
+                width: '300px',
+              }}
+            />
+          </>
+        )}
+        <h5 style={{ marginBottom: 0, paddingTop: '8px' }}>UCAN</h5>
+        <pre>
+          <code>{ucan}</code>
+        </pre>
+      </details>
+    </div>
+  )
+}
 
 /**
  *


### PR DESCRIPTION
After the user verifies their email, show them a pricing table if they haven't already selected a plan. This will let them finish this part of the flow without being redirected to the console again later.