### PR TITLE
fix: change partition key for space diff to not use customer

### DIFF
--- a/billing/data/space-diff.js
+++ b/billing/data/space-diff.js
@@ -10,7 +10,6 @@ import { EncodeFailure, DecodeFailure, Schema } from './lib.js'
  */
 
 export const schema = Schema.struct({
-  customer: Schema.did({ method: 'mailto' }),
   space: Schema.did(),
   provider: Schema.did({ method: 'web' }),
   subscription: Schema.text(),
@@ -28,9 +27,8 @@ export const encode = input => {
   try {
     return {
       ok: {
-        pk: `${input.customer}#${input.provider}#${input.space}`,
+        pk: `${input.provider}#${input.space}`,
         sk: `${input.receiptAt}#${input.cause}`,
-        customer: input.customer,
         space: input.space,
         provider: input.provider,
         subscription: input.subscription,
@@ -54,7 +52,6 @@ export const decode = input => {
   try {
     return {
       ok: {
-        customer: Schema.did({ method: 'mailto' }).from(input.customer),
         space: Schema.did().from(input.space),
         provider: Schema.did({ method: 'web' }).from(input.provider),
         subscription: /** @type {string} */ (input.subscription),
@@ -75,7 +72,7 @@ export const lister = {
   /** @type {import('../lib/api').Encoder<SpaceDiffListKey, SpaceDiffListStoreRecord>} */
   encodeKey: input => ({
     ok: {
-      pk: `${input.customer}#${input.provider}#${input.space}`,
+      pk: `${input.provider}#${input.space}`,
       sk: input.from.toISOString()
     }
   })

--- a/billing/functions/ucan-stream.js
+++ b/billing/functions/ucan-stream.js
@@ -2,7 +2,6 @@ import * as Sentry from '@sentry/serverless'
 import { toString, fromString } from 'uint8arrays'
 import * as Link from 'multiformats/link'
 import { createSpaceDiffStore } from '../tables/space-diff.js'
-import { createSubscriptionStore } from '../tables/subscription.js'
 import { createConsumerStore } from '../tables/consumer.js'
 import { expect, mustGetEnv } from './lib.js'
 import { findSpaceUsageDeltas, storeSpaceUsageDelta } from '../lib/ucan-stream.js'
@@ -16,7 +15,6 @@ Sentry.AWSLambda.init({
 /**
  * @typedef {{
  *   spaceDiffTable?: string
- *   subscriptionTable?: string
  *   consumerTable?: string
  *   region?: 'us-west-2'|'us-east-2'
  * }} CustomHandlerContext
@@ -31,7 +29,6 @@ export const handler = Sentry.AWSLambda.wrapHandler(
     /** @type {CustomHandlerContext|undefined} */
     const customContext = context?.clientContext?.Custom
     const spaceDiffTable = customContext?.spaceDiffTable ?? mustGetEnv('SPACE_DIFF_TABLE_NAME')
-    const subscriptionTable = customContext?.subscriptionTable ?? mustGetEnv('SUBSCRIPTION_TABLE_NAME')
     const consumerTable = customContext?.consumerTable ?? mustGetEnv('CONSUMER_TABLE_NAME')
     const region = customContext?.region ?? mustGetEnv('AWS_REGION')
   
@@ -45,7 +42,6 @@ export const handler = Sentry.AWSLambda.wrapHandler(
 
     const ctx = {
       spaceDiffStore: createSpaceDiffStore({ region }, { tableName: spaceDiffTable }),
-      subscriptionStore: createSubscriptionStore({ region }, { tableName: subscriptionTable }),
       consumerStore: createConsumerStore({ region }, { tableName: consumerTable })
     }
     expect(

--- a/billing/lib/api.ts
+++ b/billing/lib/api.ts
@@ -4,7 +4,7 @@ import { DID, Link, URI, LinkJSON, Result, Capabilities, Unit, Failure } from '@
 
 /**
  * Captures a size change that occurred for a given resource due to a
- * service invocation sucha s store/add or store/remove.
+ * service invocation such as store/add or store/remove.
  */
 export interface UsageDelta {
   /** Resource that changed size. */
@@ -23,8 +23,6 @@ export interface SpaceDiff {
   provider: ProviderDID
   /** Space that changed size. */
   space: ConsumerDID
-  /** Customer responsible for paying for the space at the time the size changed. */
-  customer: CustomerDID
   /** Subscription in use when the size changed. */
   subscription: string
   /** UCAN invocation that caused the size change. */
@@ -38,7 +36,6 @@ export interface SpaceDiff {
 }
 
 export interface SpaceDiffListKey {
-  customer: CustomerDID
   provider: ProviderDID
   space: ConsumerDID
   /** Receipt time the diffs should be listed from (inclusive). */

--- a/billing/lib/space-billing-queue.js
+++ b/billing/lib/space-billing-queue.js
@@ -7,13 +7,13 @@ const GB = 1024 * 1024 * 1024
  * @param {{ spaceDiffStore: import('./api').SpaceDiffStore }} ctx
  * @returns {AsyncIterable<import('@ucanto/interface').Result<import('./api').SpaceDiff[], import('@ucanto/interface').Failure>>}
  */
-const iterateSpaceDiffs = async function * ({ customer, provider, space, from, to }, ctx) {
+const iterateSpaceDiffs = async function * ({ provider, space, from, to }, ctx) {
   /** @type {string|undefined} */
   let cursor
   let done = false
   while (true) {
     const spaceDiffList = await ctx.spaceDiffStore.list(
-      { customer, provider, space, from },
+      { provider, space, from },
       { cursor, size: 1000 }
     )
     if (spaceDiffList.error) return spaceDiffList

--- a/billing/lib/ucan-stream.js
+++ b/billing/lib/ucan-stream.js
@@ -50,7 +50,6 @@ export const findSpaceUsageDeltas = messages => {
  * @param {import('./api.js').UsageDelta} delta
  * @param {{
  *   spaceDiffStore: import('./api').SpaceDiffStore
- *   subscriptionStore: import('./api').SubscriptionStore
  *   consumerStore: import('./api').ConsumerStore
  * }} ctx
  * @returns {Promise<import('@ucanto/interface').Result<import('@ucanto/interface').Unit>>}
@@ -62,11 +61,7 @@ export const storeSpaceUsageDelta = async (delta, ctx) => {
   // There should only be one subscription per provider, but in theory you
   // could have multiple providers for the same consumer (space).
   for (const consumer of consumerList.ok.results) {
-    const subGet = await ctx.subscriptionStore.get({ provider: consumer.provider, subscription: consumer.subscription })
-    if (subGet.error) return subGet
-
     const spaceDiffPut = await ctx.spaceDiffStore.put({
-      customer: subGet.ok.customer,
       provider: consumer.provider,
       subscription: consumer.subscription,
       space: delta.resource,

--- a/billing/tables/space-diff.js
+++ b/billing/tables/space-diff.js
@@ -8,9 +8,9 @@ import { validate, encode, lister, decode } from '../data/space-diff.js'
  */
 export const spaceDiffTableProps = {
   fields: {
-    /** customer#provider#space */
+    /** Composite key with format: "provider#space" */
     pk: 'string',
-    /** receiptAt#cause */
+    /** Composite key with format: "receiptAt#cause" */
     sk: 'string',
     /** Customer DID (did:mailto:...). */
     customer: 'string',

--- a/billing/tables/space-snapshot.js
+++ b/billing/tables/space-snapshot.js
@@ -8,7 +8,7 @@ import { validate, encode, decode, encodeKey } from '../data/space-snapshot.js'
  */
 export const spaceSnapshotTableProps = {
   fields: {
-    /** provider#space */
+    /** Composite key with format: "provider#space" */
     pk: 'string',
     /**
      * CSV Space DID and Provider DID.

--- a/billing/tables/usage.js
+++ b/billing/tables/usage.js
@@ -8,7 +8,7 @@ import { validate, encode } from '../data/usage.js'
  */
 export const usageTableProps = {
   fields: {
-    /** from#provider#space */
+    /** Composite key with format: "from#provider#space" */
     sk: 'string',
     /** Customer DID (did:mailto:...). */
     customer: 'string',

--- a/billing/test/helpers/context.js
+++ b/billing/test/helpers/context.js
@@ -124,15 +124,6 @@ export const createUCANStreamTestContext = async () => {
 
   const spaceDiffTableName = await createTable(awsServices.dynamo.client, spaceDiffTableProps, 'space-diff-')
   const spaceDiffStore = createSpaceDiffStore(awsServices.dynamo.client, { tableName: spaceDiffTableName })
-  const subscriptionTableName = await createTable(awsServices.dynamo.client, subscriptionTableProps, 'subscription-')
-  const subscriptionStore = {
-    ...createSubscriptionStore(awsServices.dynamo.client, { tableName: subscriptionTableName }),
-    ...createStorePutterClient(awsServices.dynamo.client, {
-      tableName: subscriptionTableName,
-      validate: validateSubscription, // assume test data is valid
-      encode: encodeSubscription
-    })
-  }
   const consumerTableName = await createTable(awsServices.dynamo.client, consumerTableProps, 'consumer-')
   const consumerStore = {
     ...createConsumerStore(awsServices.dynamo.client, { tableName: consumerTableName }),
@@ -143,7 +134,7 @@ export const createUCANStreamTestContext = async () => {
     })
   }
 
-  return { consumerStore, subscriptionStore, spaceDiffStore }
+  return { consumerStore, spaceDiffStore }
 }
 
 /**

--- a/billing/test/lib/api.ts
+++ b/billing/test/lib/api.ts
@@ -44,7 +44,6 @@ export interface StripeTestContext {
 
 export interface UCANStreamTestContext {
   spaceDiffStore: SpaceDiffStore
-  subscriptionStore: SubscriptionStore & StorePutter<Subscription>
   consumerStore: ConsumerStore & StorePutter<Consumer>
 }
 

--- a/billing/test/lib/space-billing-queue.js
+++ b/billing/test/lib/space-billing-queue.js
@@ -17,7 +17,6 @@ export const test = {
     await ctx.spaceDiffStore.put({
       provider: consumer.provider,
       space: consumer.consumer,
-      customer: customer.customer,
       subscription: consumer.subscription,
       cause: randomLink(),
       delta,
@@ -80,7 +79,6 @@ export const test = {
     await ctx.spaceDiffStore.put({
       provider: consumer.provider,
       space: consumer.consumer,
-      customer: customer.customer,
       subscription: consumer.subscription,
       cause: randomLink(),
       delta,
@@ -92,7 +90,6 @@ export const test = {
     await ctx.spaceDiffStore.put({
       provider: consumer.provider,
       space: consumer.consumer,
-      customer: customer.customer,
       subscription: consumer.subscription,
       cause: randomLink(),
       delta: -delta,
@@ -163,7 +160,6 @@ export const test = {
     await ctx.spaceDiffStore.put({
       provider: consumer.provider,
       space: consumer.consumer,
-      customer: customer.customer,
       subscription: consumer.subscription,
       cause: randomLink(),
       delta,

--- a/billing/test/lib/ucan-stream.js
+++ b/billing/test/lib/ucan-stream.js
@@ -1,10 +1,8 @@
 import { Schema } from '@ucanto/core'
 import { findSpaceUsageDeltas, storeSpaceUsageDelta } from '../../lib/ucan-stream.js'
 import { randomConsumer } from '../helpers/consumer.js'
-import { randomCustomer } from '../helpers/customer.js'
 import { randomLink } from '../helpers/dag.js'
 import { randomDID } from '../helpers/did.js'
-import { randomSubscription } from '../helpers/subscription.js'
 
 /** @type {import('./api').TestSuite<import('./api').UCANStreamTestContext>} */
 export const test = {
@@ -74,16 +72,9 @@ export const test = {
     }
   },
   'should store space diffs': async (/** @type {import('entail').assert} */ assert, ctx) => {
-    const customer = randomCustomer()
     const consumer = await randomConsumer()
-    const subscription = await randomSubscription({
-      customer: customer.customer,
-      subscription: consumer.subscription,
-      provider: consumer.provider
-    })
 
     await ctx.consumerStore.put(consumer)
-    await ctx.subscriptionStore.put(subscription)
 
     const from = new Date()
 
@@ -134,7 +125,6 @@ export const test = {
     }
 
     const res = await ctx.spaceDiffStore.list({
-      customer: customer.customer,
       provider: consumer.provider,
       space: consumer.consumer,
       from
@@ -146,10 +136,9 @@ export const test = {
     for (const r of receipts) {
       assert.ok(res.ok.results.some(d => (
         d.cause.toString() === r.invocationCid.toString() &&
-        d.customer === customer.customer &&
         d.provider === consumer.provider &&
         d.space === r.value.att[0].with &&
-        d.subscription === subscription.subscription &&
+        d.subscription === consumer.subscription &&
         d.delta === r.value.att[0].nb?.size
       )))
     }

--- a/docs/billing.tldr
+++ b/docs/billing.tldr
@@ -20,7 +20,7 @@
         "version": 2
       },
       "instance": {
-        "version": 21
+        "version": 22
       },
       "instance_page_state": {
         "version": 5
@@ -77,7 +77,6 @@
         "tldraw:horizontalAlign": "middle"
       },
       "brush": null,
-      "scribble": null,
       "cursor": {
         "type": "default",
         "rotation": 0
@@ -89,8 +88,8 @@
       "screenBounds": {
         "x": 0,
         "y": 0,
-        "w": 1616,
-        "h": 557
+        "w": 1246,
+        "h": 562
       },
       "zoomBrush": null,
       "isGridMode": true,
@@ -107,8 +106,9 @@
       "isChangingStyle": false,
       "isReadonly": false,
       "meta": {},
-      "id": "instance:instance",
       "currentPageId": "page:Rrzf2lpl3e1GzXW65i7-e",
+      "scribbles": [],
+      "id": "instance:instance",
       "typeName": "instance"
     },
     {
@@ -122,9 +122,9 @@
     {
       "id": "pointer:pointer",
       "typeName": "pointer",
-      "x": -237.73088222762954,
-      "y": 750.2645005862756,
-      "lastActivityTimestamp": 1698841502706,
+      "x": 1464.175242853933,
+      "y": 632.0152461466541,
+      "lastActivityTimestamp": 1699361549206,
       "meta": {}
     },
     {
@@ -135,9 +135,9 @@
       "typeName": "page"
     },
     {
-      "x": 2429.1435961944767,
-      "y": 534.384849684416,
-      "z": 0.22046993791754974,
+      "x": -382.9709103147887,
+      "y": -303.8980925854103,
+      "z": 0.9539275731330452,
       "meta": {},
       "id": "camera:page:Rrzf2lpl3e1GzXW65i7-e",
       "typeName": "camera"
@@ -2621,7 +2621,7 @@
     },
     {
       "x": 1180,
-      "y": 520,
+      "y": 530,
       "rotation": 0,
       "isLocked": false,
       "opacity": 1,
@@ -2630,8 +2630,8 @@
       "props": {
         "color": "grey",
         "size": "s",
-        "w": 282.6640625,
-        "text": "pk: customer#provider#space\nsk: receiptAt#cause\ncustomer: DID string\nspace: DID string\nprovider: DID string\nsubscription: string\ncause: CID string\ndelta: +/- bytes number\nreceiptAt: ISO string\ninsertedAt: ISO string",
+        "w": 219.2890625,
+        "text": "pk: provider#space\nsk: receiptAt#cause\nspace: DID string\nprovider: DID string\nsubscription: string\ncause: CID string\ndelta: +/- bytes number\nreceiptAt: ISO string\ninsertedAt: ISO string",
         "font": "draw",
         "align": "start",
         "autoSize": true,

--- a/filecoin/test/filecoin-service.test.js
+++ b/filecoin/test/filecoin-service.test.js
@@ -17,7 +17,8 @@ import { getQueues, getStores } from './helpers/service-context.js'
 const queueNames = ['pieceOfferQueue', 'filecoinSubmitQueue']
 
 test.before(async (t) => {
-  await delay(1000)
+  // wait for previous resources to be down
+  await delay(5000)
   /** @type {Record<string, QueueContext>} */
   const queues = {}
   // /** @type {import('@aws-sdk/client-sqs').Message[]} */

--- a/stacks/billing-stack.js
+++ b/stacks/billing-stack.js
@@ -93,11 +93,10 @@ export function BillingStack ({ stack, app }) {
 
   // Lambda that receives UCAN stream events and writes diffs to spaceSizeDiffTable
   const ucanStreamHandler = new Function(stack, 'ucan-stream-handler', {
-    permissions: [spaceDiffTable, subscriptionTable, consumerTable],
+    permissions: [spaceDiffTable, consumerTable],
     handler: 'functions/ucan-stream.handler',
     environment: {
       SPACE_DIFF_TABLE_NAME: spaceDiffTable.tableName,
-      SUBSCRIPTION_TABLE_NAME: subscriptionTable.tableName,
       CONSUMER_TABLE_NAME: consumerTable.tableName
     }
   })


### PR DESCRIPTION
There's no reason for space diffs to store the customer, or include it in the partition key 🤦. If the customer for a given space changes we cannot accurately account for space size changes. I'm not sure why it would, but if it did we'd not be able to get an accurate list of changes for a space.

Also, for retrieving usage in the frontend it's also problematic as we have to somehow look up the customer for a given space before we can get hold of the diffs.