### PR TITLE
feat: new piece table for storefront

### DIFF
--- a/stacks/upload-db-stack.js
+++ b/stacks/upload-db-stack.js
@@ -47,9 +47,9 @@ export function UploadDbStack({ stack, app }) {
 
   /**
    * This table takes a stored CAR and makes an entry in the piece table
-   * Used by the filecoin/* service capabilities. // TODO
+   * Used by the filecoin/* service capabilities.
    */
-  const pieceTable = new Table(stack, 'piece-v1', {
+  const pieceTable = new Table(stack, 'piece-v2', {
     ...pieceTableProps,
     // information that will be written to the stream
     stream: 'new_image',

--- a/test/filecoin.test.js
+++ b/test/filecoin.test.js
@@ -27,7 +27,7 @@ import { waitForStoreOperationOkResult } from './helpers/store.js'
 test.before(t => {
   t.context = {
     apiEndpoint: getApiEndpoint(),
-    pieceDynamo: getDynamoDb('piece-v1'),
+    pieceDynamo: getDynamoDb('piece-v2'),
   }
 })
 


### PR DESCRIPTION
We will restart the Filecoin Pipeline for launch. So, let's create a `piece-v2` table

Given Dynamo makes it difficult to clean an entire table (and expensive!) it is better to just create a new Table to re-start the pipeline. We could also delete the table and re-deploy, however most of the content already there will still at some point be put into Filecoin deals, so already knowing their PieceCIDv2 will mean less compute costs.