### PR TITLE
feat: add receipts endpoint

### DIFF
--- a/filecoin/store/receipt.js
+++ b/filecoin/store/receipt.js
@@ -110,7 +110,6 @@ export const useReceiptStore = (s3client, invocationBucketName, workflowBucketNa
         headers: {},
       })
 
-
       // @ts-expect-error unknown link does not mach expectations
       const receipt = agentMessage.receipts.get(invocationCid.toString())
       if (!receipt) {

--- a/stacks/ucan-invocation-stack.js
+++ b/stacks/ucan-invocation-stack.js
@@ -36,6 +36,7 @@ export function UcanInvocationStack({ stack, app }) {
     cdk: {
       bucket: {
         ...getBucketConfig('workflow-store', app.stage),
+        // change the defaults accordingly to allow access via new Policy
         blockPublicAccess: {
           blockPublicAcls: true,
           ignorePublicAcls: true,
@@ -45,7 +46,7 @@ export function UcanInvocationStack({ stack, app }) {
       },
     }
   })
-  // Make bucket public
+  // Make bucket public for `s3:GetObject` command
   workflowBucket.cdk.bucket.addToResourcePolicy(
     new PolicyStatement({
       actions: ['s3:GetObject'],

--- a/stacks/upload-api-stack.js
+++ b/stacks/upload-api-stack.js
@@ -121,6 +121,7 @@ export function UploadApiStack({ stack, app }) {
       'GET /error':   'functions/get.error',
       'GET /version': 'functions/get.version',
       'GET /metrics': 'functions/metrics.handler',
+      'GET /receipt/{taskCid}': 'functions/receipt.handler',
       'GET /storefront-cron': 'functions/storefront-cron.handler',
       // AWS API Gateway does not know trailing slash... and Grafana Agent puts trailing slash
       'GET /metrics/{proxy+}': 'functions/metrics.handler',

--- a/test/filecoin.test.js
+++ b/test/filecoin.test.js
@@ -128,7 +128,6 @@ test('w3filecoin integration flow', async t => {
       redirect: 'manual'
     }
   )
-  console.log('rrr', workflowWithReceiptResponse.headers.get('location'))
   t.is(workflowWithReceiptResponse.status, 302)
   const workflowLocation = workflowWithReceiptResponse.headers.get('location')
   if (!workflowLocation) {

--- a/upload-api/buckets/invocation-store.js
+++ b/upload-api/buckets/invocation-store.js
@@ -116,12 +116,12 @@ export const useInvocationStore = (s3client, bucketName) => {
       })
       const listObject = await s3client.send(listObjectCmd)
       const carEntry = listObject.Contents?.find(
-        content => content.Key?.endsWith('.workflow')
+        content => content.Key?.endsWith('.out')
       )
       if (!carEntry) {
         return
       }
-      return carEntry.Key?.replace(prefix, '').replace('.workflow', '')
+      return carEntry.Key?.replace(prefix, '').replace('.out', '')
     }
   }
 }

--- a/upload-api/functions/receipt.js
+++ b/upload-api/functions/receipt.js
@@ -1,0 +1,57 @@
+import * as Sentry from '@sentry/serverless'
+import { parseLink } from '@ucanto/server'
+
+import { createInvocationStore } from '../buckets/invocation-store.js'
+import { mustGetEnv } from './utils.js'
+
+Sentry.AWSLambda.init({
+  environment: process.env.SST_STAGE,
+  dsn: process.env.SENTRY_DSN,
+  tracesSampleRate: 1.0,
+})
+
+const AWS_REGION = process.env.AWS_REGION || 'us-west-2'
+
+/**
+ * AWS HTTP Gateway handler for GET /receipt.
+ *
+ * @param {import('aws-lambda').APIGatewayProxyEventV2} event
+ */
+export async function receiptGet (event) {
+  const {
+    invocationBucketName,
+    workflowBucketName,
+  } = getLambdaEnv()
+  const invocationBucket = createInvocationStore(
+    AWS_REGION,
+    invocationBucketName
+  )
+
+  if (!event.pathParameters?.taskCid) {
+    return {
+      statusCode: 400,
+      body: Buffer.from(`no task cid received`).toString('base64'),
+    }
+  }
+  const taskCid = parseLink(event.pathParameters.taskCid)
+
+  const workflowLinkWithReceipt = await invocationBucket.getWorkflowLink(taskCid.toString())
+  const url = `https://${workflowBucketName}.s3.${AWS_REGION}.amazonaws.com/${workflowLinkWithReceipt}/${workflowLinkWithReceipt}`
+
+  // redirect to bucket
+  return {
+    statusCode: 302,
+    headers: {
+      Location: url
+    }
+  }
+}
+
+function getLambdaEnv () {
+  return {
+    invocationBucketName: mustGetEnv('INVOCATION_BUCKET_NAME'),
+    workflowBucketName: mustGetEnv('WORKFLOW_BUCKET_NAME'),
+  }
+}
+
+export const handler = Sentry.AWSLambda.wrapHandler(receiptGet)

--- a/upload-api/types.ts
+++ b/upload-api/types.ts
@@ -5,6 +5,9 @@ import { CID } from 'multiformats/cid'
 import { Kinesis } from '@aws-sdk/client-kinesis'
 import { AccountDID, ProviderDID, Service, SpaceDID } from '@web3-storage/upload-api'
 
+export interface StoreOperationError extends Error {
+  name: 'StoreOperationFailed'
+}
 
 export interface UcanLogCtx extends WorkflowCtx, ReceiptBlockCtx {
   basicAuth: string


### PR DESCRIPTION
Adds receipts endpoint with redirect to workflow bucket where receipt for asked task will be available.

Bucket was made public to accept GETs, you can see the generated policy [here](https://s3.console.aws.amazon.com/s3/buckets/workflow-store-pr275-0?region=us-east-2&tab=permissions) . IAM Role has general access to the bucket, while `"Principal": "*"` can perform `GetObject`.

Integration tests were added to inspect receipt from `filecoin/offer` invocation