### PR TITLE
feat: filecoin metrics for ucan stream prometheus and updates metrics endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16346,7 +16346,11 @@
         "@aws-sdk/client-dynamodb": "^3.226.0",
         "@aws-sdk/client-eventbridge": "^3.218.0",
         "@sentry/serverless": "^7.22.0",
+        "@ucanto/core": "9.0.0",
+        "@ucanto/transport": "9.0.0",
         "@web3-storage/capabilities": "^11.3.1",
+        "@web3-storage/data-segment": "5.0.0",
+        "multiformats": "^11.0.1",
         "uint8arrays": "^4.0.2"
       },
       "devDependencies": {
@@ -16354,10 +16358,22 @@
         "@aws-sdk/client-s3": "^3.226.0",
         "@serverless-stack/resources": "*",
         "@ucanto/interface": "^9.0.0",
+        "@web3-storage/filecoin-api": "4.3.0",
         "ava": "^4.3.3",
-        "multiformats": "^11.0.1",
         "nanoid": "4.0.0",
         "testcontainers": "^8.13.0"
+      }
+    },
+    "ucan-invocation/node_modules/@ucanto/core": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@ucanto/core/-/core-9.0.0.tgz",
+      "integrity": "sha512-O2c+UOQ5wAvUsuN7BbZR6QAoUgYpWzN0HAAVbNBLT4I8/OUzMcxSYeu08/ph0sNtLGlOPDcPn+ANclTwxc5UcA==",
+      "dependencies": {
+        "@ipld/car": "^5.1.0",
+        "@ipld/dag-cbor": "^9.0.0",
+        "@ipld/dag-ucan": "^3.4.0",
+        "@ucanto/interface": "^9.0.0",
+        "multiformats": "^11.0.2"
       }
     },
     "ucan-invocation/node_modules/nanoid": {

--- a/stacks/firehose-stack.js
+++ b/stacks/firehose-stack.js
@@ -326,7 +326,7 @@ export function UcanFirehoseStack ({ stack, app }) {
   })
   uploadAddTable.addDependsOn(glueDatabase)
 
-    // creates a table that can be seen in the AWS Glue table browser at 
+  // creates a table that can be seen in the AWS Glue table browser at 
   // https://console.aws.amazon.com/glue/home#/v2/data-catalog/tables
   // and in the data browser in the Athena Query editor at
   // https://console.aws.amazon.com/athena/home#/query-editor

--- a/stacks/ucan-invocation-stack.js
+++ b/stacks/ucan-invocation-stack.js
@@ -143,6 +143,30 @@ export function UcanInvocationStack({ stack, app }) {
     handler: 'functions/metrics-upload-remove-total.consumer',
     deadLetterQueue: metricsUploadRemoveTotalDLQ.cdk.queue,
   })
+
+  // aggregate/offer total
+  const metricsAggregateOfferTotalDLQ = new Queue(stack, 'metrics-aggregate-offer-total-dlq')
+  const metricsAggregateOfferTotalConsumer = new Function(stack, 'metrics-aggregate-offer-total-consumer', {
+    environment: {
+      METRICS_TABLE_NAME: adminMetricsTable.tableName,
+      WORKFLOW_BUCKET_NAME: workflowBucket.bucketName,
+    },
+    permissions: [adminMetricsTable, workflowBucket],
+    handler: 'functions/metrics-aggregate-offer-total.consumer',
+    deadLetterQueue: metricsAggregateOfferTotalDLQ.cdk.queue,
+  })
+
+  // aggregate/accept total
+  const metricsAggregateAcceptTotalDLQ = new Queue(stack, 'metrics-aggregate-accept-total-dlq')
+  const metricsAggregateAcceptTotalConsumer = new Function(stack, 'metrics-aggregate-accept-total-consumer', {
+    environment: {
+      METRICS_TABLE_NAME: adminMetricsTable.tableName,
+      WORKFLOW_BUCKET_NAME: workflowBucket.bucketName,
+    },
+    permissions: [adminMetricsTable, workflowBucket],
+    handler: 'functions/metrics-aggregate-accept-total.consumer',
+    deadLetterQueue: metricsAggregateAcceptTotalDLQ.cdk.queue,
+  })
   
   // metrics per space
   const spaceMetricsDLQ = new Queue(stack, 'space-metrics-dlq')
@@ -271,6 +295,23 @@ export function UcanInvocationStack({ stack, app }) {
       },
       metricsUploadRemoveTotalConsumer: {
         function: metricsUploadRemoveTotalConsumer,
+        cdk: {
+          eventSource: {
+            ...(getKinesisEventSourceConfig(stack))
+          }
+        }
+      },
+      // Filecoin metrics
+      metricsAggregateOfferTotalConsumer: {
+        function: metricsAggregateOfferTotalConsumer,
+        cdk: {
+          eventSource: {
+            ...(getKinesisEventSourceConfig(stack))
+          }
+        }
+      },
+      metricsAggregateAcceptTotalConsumer: {
+        function: metricsAggregateAcceptTotalConsumer,
         cdk: {
           eventSource: {
             ...(getKinesisEventSourceConfig(stack))

--- a/ucan-invocation/constants.js
+++ b/ucan-invocation/constants.js
@@ -6,6 +6,10 @@ import {
   add as uploadAdd,
   remove as uploadRemove
 } from '@web3-storage/capabilities/upload'
+import {
+  aggregateOffer,
+  aggregateAccept
+} from '@web3-storage/capabilities/filecoin/dealer'
 
 export const STREAM_TYPE = {
   WORKFLOW: 'workflow',
@@ -17,6 +21,8 @@ export const STORE_ADD = storeAdd.can
 export const STORE_REMOVE = storeRemove.can
 export const UPLOAD_ADD = uploadAdd.can
 export const UPLOAD_REMOVE = uploadRemove.can
+export const AGGREGATE_OFFER = aggregateOffer.can
+export const AGGREGATE_ACCEPT = aggregateAccept.can
 
 // Admin Metrics
 export const METRICS_NAMES = {
@@ -26,9 +32,13 @@ export const METRICS_NAMES = {
   STORE_ADD_SIZE_TOTAL: `${STORE_ADD}-size-total`,
   STORE_REMOVE_TOTAL: `${STORE_REMOVE}-total`,
   STORE_REMOVE_SIZE_TOTAL: `${STORE_REMOVE}-size-total`,
+  AGGREGATE_OFFER_TOTAL: `${AGGREGATE_OFFER}-total`,
+  AGGREGATE_OFFER_PIECES_TOTAL: `${AGGREGATE_OFFER}-pieces-total`,
+  AGGREGATE_OFFER_PIECES_SIZE_TOTAL: `${AGGREGATE_OFFER}-pieces-size-total`,
+  AGGREGATE_ACCEPT_TOTAL: `${AGGREGATE_ACCEPT}-total`,
 }
 
-// Spade Metrics
+// Space Metrics
 export const SPACE_METRICS_NAMES = {
   UPLOAD_ADD_TOTAL: `${UPLOAD_ADD}-total`,
   UPLOAD_REMOVE_TOTAL: `${UPLOAD_REMOVE}-total`,

--- a/ucan-invocation/errors.js
+++ b/ucan-invocation/errors.js
@@ -1,0 +1,27 @@
+import * as Server from '@ucanto/server'
+
+export const DecodeBlockOperationErrorName = /** @type {const} */ (
+  'DecodeBlockOperationError'
+)
+export class DecodeBlockOperationError extends Server.Failure {
+  get reason() {
+    return this.message
+  }
+
+  get name() {
+    return DecodeBlockOperationErrorName
+  }
+}
+
+export const NotFoundWorkflowErrorName = /** @type {const} */ (
+  'NotFoundWorkflowError'
+)
+export class NotFoundWorkflowError extends Server.Failure {
+  get reason() {
+    return this.message
+  }
+
+  get name() {
+    return NotFoundWorkflowErrorName
+  }
+}

--- a/ucan-invocation/filecoin.js
+++ b/ucan-invocation/filecoin.js
@@ -1,0 +1,193 @@
+import * as CAR from '@ucanto/transport/car'
+import { CBOR } from '@ucanto/core'
+import * as Block from 'multiformats/block'
+import { sha256 } from 'multiformats/hashes/sha2'
+import { Piece } from '@web3-storage/data-segment'
+
+import { hasOkReceipt } from './utils/receipt.js'
+import { AGGREGATE_ACCEPT, AGGREGATE_OFFER, METRICS_NAMES } from './constants.js'
+import { DecodeBlockOperationError, NotFoundWorkflowError } from './errors.js'
+
+/**
+ * @typedef {import('@web3-storage/capabilities/types.js').AggregateOffer} AggregateOffer
+ * @typedef {import('@web3-storage/capabilities/types.js').AggregateAccept} AggregateAccept
+ * @typedef {import('@web3-storage/data-segment').PieceLink} PieceLink
+ * @typedef {{ capabilities: AggregateOffer[], invocationCid: string }} AggregateOfferInvocation
+ * @typedef {{ capabilities: AggregateAccept[], invocationCid: string }} AggregateAcceptInvocation
+ * @typedef {{ aggregate: PieceLink, pieces: PieceLink[] }} AggregateOfferInfo
+ * @typedef {DecodeBlockOperationError | NotFoundWorkflowError} AggregateOfferGetError
+ * @typedef {import('@ucanto/interface').Result<AggregateOfferInfo, AggregateOfferGetError>} AggregateOfferGet
+ */
+
+/**
+ * Update total metrics for `aggregate/accept` receipts.
+ * Metrics:
+ * - AGGREGATE_ACCEPT_TOTAL: increment number of `aggregate/accept` success receipts
+ * 
+ * @param {import('./types').UcanInvocation[]} ucanInvocations
+ * @param {import('./types').FilecoinMetricsCtx} ctx
+ */
+export async function updateAggregateAcceptTotal (ucanInvocations, ctx) {
+  const aggregateAcceptInvocations = ucanInvocations.filter(
+    inv => inv.value.att.find(a => a.can === AGGREGATE_ACCEPT) && hasOkReceipt(inv)
+  )
+
+  await ctx.filecoinMetricsStore.incrementTotals({
+    [METRICS_NAMES.AGGREGATE_ACCEPT_TOTAL]: aggregateAcceptInvocations.length
+    // TODO: time needed in receipt https://github.com/web3-storage/w3up/issues/970
+  })
+}
+
+/**
+ * Update total metrics for `aggregate/accept` receipts.
+ * Metrics:
+ * - AGGREGATE_OFFER_TOTAL: increment number of `aggregate/offer` success receipts
+ * - AGGREGATE_OFFER_PIECES_TOTAL: increment number of pieces included in `aggregate/offer` success receipts
+ * - AGGREGATE_OFFER_PIECES_SIZE_TOTAL: increment size of pieces included of `aggregate/offer` success receipts
+ *
+ * @param {import('./types').UcanInvocation[]} ucanInvocations
+ * @param {import('./types').FilecoinMetricsCtx} ctx
+ */
+export async function updateAggregateOfferTotal (ucanInvocations, ctx) {
+  // Get a Map of workflows that include aggregate offer receipts
+  /** @type {Map<string, AggregateOfferInvocation>} */
+  const workflowsWithAggregateOffers = getWorkflowsWithReceiptForCapability(ucanInvocations, AGGREGATE_OFFER)
+
+  // From workflows that include aggregate offer receipts, try to get the block with Pieces included in Aggregate
+  /** @type {AggregateOfferGet[]} */
+  const aggregateOfferGets = (await Promise.all(
+    Array.from(workflowsWithAggregateOffers.entries()).map(async ([carCid, aggregateOfferInvocation]) => {
+      const agentMessage = await getAgentMessage(carCid, ctx)
+      if (agentMessage.error) {
+        return [{
+          error: agentMessage.error,
+          ok: undefined
+        }]
+      }
+
+      return Promise.all(aggregateOfferInvocation.capabilities.map(aggregateOfferCap => getOfferInfoBlock(aggregateOfferCap, agentMessage.ok)))
+    })
+  // @ts-expect-error error types
+  )).flatMap(get => get)
+  const aggregateOfferGetError = aggregateOfferGets.find(get => get.error)
+  if (aggregateOfferGetError) {
+    throw aggregateOfferGetError.error
+  }
+
+  /** @type {AggregateOfferInfo[]} */
+  // @ts-expect-error ts thinks it may be undefined
+  const aggregateOffers = aggregateOfferGets.map(get => get.ok)
+
+  // Increment metrics totals
+  await ctx.filecoinMetricsStore.incrementTotals({
+    [METRICS_NAMES.AGGREGATE_OFFER_TOTAL]: aggregateOffers.length,
+    [METRICS_NAMES.AGGREGATE_OFFER_PIECES_TOTAL]: aggregateOffers.reduce((acc, offer) => {
+      const sum = acc + offer.pieces.length
+      return sum
+    }, 0),
+    [METRICS_NAMES.AGGREGATE_OFFER_PIECES_SIZE_TOTAL]: Number(aggregateOffers.reduce((acc, offer) => {
+      return acc + offer.pieces.reduce((acc, pieceLink) => {
+        return acc + Piece.fromLink(pieceLink).size
+      }, 0n)
+    }, 0n))
+  })
+}
+
+/**
+ * Get a map of workflows that include given capability.
+ *
+ * @param {import('./types').UcanInvocation[]} ucanInvocations
+ * @param {string} capability
+ */
+function getWorkflowsWithReceiptForCapability (ucanInvocations, capability) {
+  return ucanInvocations
+  .reduce(
+    (acc, workflowInvocations) => {
+      const aggregateOfferReceipts = workflowInvocations.value.att.filter(a => a.can === capability)
+
+      // If no `aggregate/offer` as receipts we can stop
+      if (!aggregateOfferReceipts.length || !hasOkReceipt(workflowInvocations)) {
+        return acc
+      }
+      // Annotate `aggregate/offer` invocations in workflow
+      const workflowCid = workflowInvocations.carCid
+      const invocationCid = workflowInvocations.invocationCid
+      acc.set(workflowCid, {
+        capabilities: aggregateOfferReceipts,
+        invocationCid
+      })
+
+      return acc
+    },
+    (new Map())
+  )
+}
+
+/**
+ * @param {string} carCid
+ * @param {import('./types').FilecoinMetricsCtx} ctx
+ */
+async function getAgentMessage (carCid, ctx) {
+  const agentMessageBytes = await ctx.workflowStore.get(carCid)
+  if (!agentMessageBytes) {
+    return {
+      error: new NotFoundWorkflowError(`not found receipt for CAR cid ${carCid}`)
+    }
+  }
+
+  const agentMessage = await CAR.request.decode({
+    body: agentMessageBytes,
+    headers: {},
+  })
+
+  return {
+    ok: agentMessage
+  }
+}
+
+/**
+ * @param {AggregateOffer} aggregateOfferCap
+ * @param {import('@ucanto/interface').AgentMessage<any>} agentMessage
+ */
+async function getOfferInfoBlock (aggregateOfferCap, agentMessage) {
+  const blockGet = await findCBORBlock(
+    aggregateOfferCap.nb.pieces,
+    agentMessage.iterateIPLDBlocks()
+  )
+
+  if (blockGet.error) {
+    return {
+      error: blockGet.error,
+      ok: undefined
+    }
+  }
+
+  return {
+    ok: {
+      aggregate: aggregateOfferCap.nb.aggregate,
+      pieces: blockGet.ok.value
+    }
+  }
+}
+
+/**
+ * @param {import('multiformats').Link} cid
+ * @param {IterableIterator<import('@ucanto/server').API.Transport.Block<unknown, number, number, 1>>} blocks
+ * @returns {Promise<import('@ucanto/server').Result<import('multiformats').BlockView, DecodeBlockOperationError>>}
+ */
+const findCBORBlock = async (cid, blocks) => {
+  let bytes
+  for (const b of blocks) {
+    if (b.cid.equals(cid)) {
+      bytes = b.bytes
+    }
+  }
+  if (!bytes) {
+    return {
+      error: new DecodeBlockOperationError(`missing block: ${cid}`),
+    }
+  }
+  return {
+    ok: await Block.create({ cid, bytes, codec: CBOR, hasher: sha256 }),
+  }
+}

--- a/ucan-invocation/functions/metrics-aggregate-accept-total.js
+++ b/ucan-invocation/functions/metrics-aggregate-accept-total.js
@@ -34,7 +34,6 @@ function getLambdaEnv () {
   return {
     metricsTableName: mustGetEnv('METRICS_TABLE_NAME'),
     workflowBucketName: mustGetEnv('WORKFLOW_BUCKET_NAME'),
-    invocationBucketName: mustGetEnv('INVOCATION_BUCKET_NAME'),
   }
 }
 

--- a/ucan-invocation/functions/metrics-aggregate-accept-total.js
+++ b/ucan-invocation/functions/metrics-aggregate-accept-total.js
@@ -1,0 +1,41 @@
+import * as Sentry from '@sentry/serverless'
+
+import { updateAggregateAcceptTotal } from '../filecoin.js'
+import { createWorkflowStore } from '../buckets/workflow-store.js'
+import { createFilecoinMetricsTable } from '../stores/filecoin-metrics.js'
+import { parseKinesisEvent } from '../utils/parse-kinesis-event.js'
+import { mustGetEnv } from './utils.js'
+
+Sentry.AWSLambda.init({
+  environment: process.env.SST_STAGE,
+  dsn: process.env.SENTRY_DSN,
+  tracesSampleRate: 1.0,
+})
+
+const AWS_REGION = process.env.AWS_REGION || 'us-west-2'
+
+/**
+ * @param {import('aws-lambda').KinesisStreamEvent} event
+ */
+async function handler(event) {
+  const ucanInvocations = parseKinesisEvent(event)
+  const {
+    metricsTableName,
+    workflowBucketName,
+  } = getLambdaEnv()
+
+  await updateAggregateAcceptTotal(ucanInvocations, {
+    filecoinMetricsStore: createFilecoinMetricsTable(AWS_REGION, metricsTableName),
+    workflowStore: createWorkflowStore(AWS_REGION, workflowBucketName),
+  })
+}
+
+function getLambdaEnv () {
+  return {
+    metricsTableName: mustGetEnv('METRICS_TABLE_NAME'),
+    workflowBucketName: mustGetEnv('WORKFLOW_BUCKET_NAME'),
+    invocationBucketName: mustGetEnv('INVOCATION_BUCKET_NAME'),
+  }
+}
+
+export const consumer = Sentry.AWSLambda.wrapHandler(handler)

--- a/ucan-invocation/functions/metrics-aggregate-offer-total.js
+++ b/ucan-invocation/functions/metrics-aggregate-offer-total.js
@@ -1,0 +1,40 @@
+import * as Sentry from '@sentry/serverless'
+
+import { updateAggregateOfferTotal } from '../filecoin.js'
+import { createWorkflowStore } from '../buckets/workflow-store.js'
+import { createFilecoinMetricsTable } from '../stores/filecoin-metrics.js'
+import { parseKinesisEvent } from '../utils/parse-kinesis-event.js'
+import { mustGetEnv } from './utils.js'
+
+Sentry.AWSLambda.init({
+  environment: process.env.SST_STAGE,
+  dsn: process.env.SENTRY_DSN,
+  tracesSampleRate: 1.0,
+})
+
+const AWS_REGION = process.env.AWS_REGION || 'us-west-2'
+
+/**
+ * @param {import('aws-lambda').KinesisStreamEvent} event
+ */
+async function handler(event) {
+  const ucanInvocations = parseKinesisEvent(event)
+  const {
+    metricsTableName,
+    workflowBucketName
+  } = getLambdaEnv()
+
+  await updateAggregateOfferTotal(ucanInvocations, {
+    filecoinMetricsStore: createFilecoinMetricsTable(AWS_REGION, metricsTableName),
+    workflowStore: createWorkflowStore(AWS_REGION, workflowBucketName),
+  })
+}
+
+function getLambdaEnv () {
+  return {
+    metricsTableName: mustGetEnv('METRICS_TABLE_NAME'),
+    workflowBucketName: mustGetEnv('WORKFLOW_BUCKET_NAME'),
+  }
+}
+
+export const consumer = Sentry.AWSLambda.wrapHandler(handler)

--- a/ucan-invocation/functions/utils.js
+++ b/ucan-invocation/functions/utils.js
@@ -1,0 +1,9 @@
+/**
+ * @param {string} name 
+ * @returns {string}
+ */
+export function mustGetEnv (name) {
+  const value = process.env[name]
+  if (!value) throw new Error(`Missing env var: ${name}`)
+  return value
+}

--- a/ucan-invocation/package.json
+++ b/ucan-invocation/package.json
@@ -9,7 +9,11 @@
     "@aws-sdk/client-dynamodb": "^3.226.0",
     "@aws-sdk/client-eventbridge": "^3.218.0",
     "@sentry/serverless": "^7.22.0",
+    "@ucanto/transport": "9.0.0",
+    "@ucanto/core": "9.0.0",
     "@web3-storage/capabilities": "^11.3.1",
+    "@web3-storage/data-segment": "5.0.0",
+    "multiformats": "^11.0.1",
     "uint8arrays": "^4.0.2"
   },
   "devDependencies": {
@@ -17,9 +21,15 @@
     "@aws-sdk/client-s3": "^3.226.0",
     "@serverless-stack/resources": "*",
     "@ucanto/interface": "^9.0.0",
+    "@web3-storage/filecoin-api": "4.3.0",
     "ava": "^4.3.3",
-    "multiformats": "^11.0.1",
     "nanoid": "4.0.0",
     "testcontainers": "^8.13.0"
+  },
+  "eslintConfig": {
+    "rules": {
+      "unicorn/prefer-array-flat": "off",
+      "unicorn/prefer-spread": "off"
+    }
   }
 }

--- a/ucan-invocation/stores/filecoin-metrics.js
+++ b/ucan-invocation/stores/filecoin-metrics.js
@@ -1,0 +1,81 @@
+import {
+  DynamoDBClient,
+  TransactWriteItemsCommand,
+  UpdateItemCommand
+} from '@aws-sdk/client-dynamodb'
+import { marshall } from '@aws-sdk/util-dynamodb'
+
+/**
+ * Abstraction layer to handle operations on metrics table.
+ *
+ * @param {string} region
+ * @param {string} tableName
+ * @param {object} [options]
+ * @param {string} [options.endpoint]
+ */
+export function createFilecoinMetricsTable (region, tableName, options = {}) {
+  const dynamoDb = new DynamoDBClient({
+    region,
+    endpoint: options.endpoint,
+  })
+
+  return useFilecoinMetricsTable(dynamoDb, tableName)
+}
+
+/**
+ * @param {DynamoDBClient} dynamoDb
+ * @param {string} tableName
+ * @returns {import('../types').FilecoinMetricsStore}
+ */
+export function useFilecoinMetricsTable (dynamoDb, tableName) {
+  return {
+
+    /**
+     * Increment total value of the metric by n.
+     *
+     * @param {string} metricName 
+     * @param {number} n 
+     */
+    incrementTotal: async (metricName, n) => {
+      const updateCmd = new UpdateItemCommand({
+        TableName: tableName,
+        UpdateExpression: `ADD #value :value`,
+          ExpressionAttributeNames: {'#value': 'value'},
+          ExpressionAttributeValues: {
+            ':value': { N: String(n) },
+          },
+        Key: marshall({
+          name: metricName
+        })
+      })
+
+      await dynamoDb.send(updateCmd)
+    },
+    /**
+     * Increment total values of the given metrics.
+     *
+     * @param {Record<string, number>} metricsToUpdate
+     */
+    incrementTotals: async (metricsToUpdate) => {
+      const transactItems = Object.entries(metricsToUpdate).map(([name, n]) => ({
+        Update: {
+          TableName: tableName,
+          UpdateExpression: `ADD #value :value`,
+            ExpressionAttributeNames: {'#value': 'value'},
+            ExpressionAttributeValues: {
+              ':value': { N: String(n) },
+            },
+          Key: marshall({
+            name
+          })
+        }
+      }))
+      
+      const cmd = new TransactWriteItemsCommand({
+        TransactItems: transactItems
+      })
+
+      await dynamoDb.send(cmd)
+    }
+  }
+}

--- a/ucan-invocation/tables/metrics.js
+++ b/ucan-invocation/tables/metrics.js
@@ -141,8 +141,7 @@ export function createMetricsTable (region, tableName, options = {}) {
       })
 
       await dynamoDb.send(updateCmd)
-    }
-    ,
+    },
     /**
      * Increment total count from upload/add operations.
      *
@@ -164,6 +163,6 @@ export function createMetricsTable (region, tableName, options = {}) {
       })
 
       await dynamoDb.send(updateCmd)
-    }
+    },
   }
 }

--- a/ucan-invocation/test/functions/metrics-aggregate-accept-total.test.js
+++ b/ucan-invocation/test/functions/metrics-aggregate-accept-total.test.js
@@ -1,0 +1,273 @@
+import { testConsumerWithBucket as test } from '../helpers/context.js'
+
+import { CBOR } from '@ucanto/core'
+import * as Signer from '@ucanto/principal/ed25519'
+import * as DealerCapabilities from '@web3-storage/capabilities/filecoin/dealer'
+import * as StoreCapabilities from '@web3-storage/capabilities/store'
+import { randomAggregate } from '@web3-storage/filecoin-api/test'
+
+import { updateAggregateAcceptTotal } from '../../filecoin.js'
+
+import { adminMetricsTableProps } from '../../tables/index.js'
+import { createFilecoinMetricsTable } from '../../stores/filecoin-metrics.js'
+import { createWorkflowStore } from '../../buckets/workflow-store.js'
+import { METRICS_NAMES, STREAM_TYPE } from '../../constants.js'
+
+import {
+  createDynamodDb,
+  createS3,
+  createBucket,
+} from '../helpers/resources.js'
+import { randomCAR } from '../helpers/random.js'
+import { createDynamoTable, getItemFromTable} from '../helpers/tables.js'
+import { createSpace } from '../helpers/ucanto.js'
+
+const REGION = 'us-west-2'
+
+/**
+ * @typedef {import('@web3-storage/data-segment').PieceLink} PieceLink
+ * @typedef {import('@web3-storage/data-segment').AggregateView} AggregateView
+ */
+
+test.before(async t => {
+  // Dynamo DB
+  const {
+    client: dynamo,
+    endpoint: dbEndpoint
+  } = await createDynamodDb({ port: 8000 })
+  t.context.dbEndpoint = dbEndpoint
+  t.context.dynamoClient = dynamo
+
+  // S3
+  const { client, clientOpts } = await createS3()
+  t.context.s3 = client
+  t.context.s3Opts = clientOpts
+})
+
+test('handles a batch of single invocation with aggregate/offer', async t => {
+  const { tableName, bucketName } = await prepareResources(t.context.dynamoClient, t.context.s3)
+
+  // Context
+  const filecoinMetricsStore = createFilecoinMetricsTable(REGION, tableName, {
+    endpoint: t.context.dbEndpoint
+  })
+  const workflowStore = createWorkflowStore(REGION, bucketName, t.context.s3Opts)
+
+  // Invocation ctx
+  const w3sService = await Signer.generate()
+  const car = await randomCAR(128)
+
+  // Generate aggregate for test
+  const { pieces, aggregate } = await randomAggregate(100, 128)
+  const offer = pieces.map((p) => p.link)
+      const piecesBlock = await CBOR.write(offer)
+
+  const invocations = [{
+    carCid: car.cid.toString(),
+    value: {
+        att: [
+          DealerCapabilities.aggregateAccept.create({
+            with: w3sService.did(),
+            nb: {
+              aggregate: aggregate.link,
+              pieces: piecesBlock.cid,
+            }
+          })
+        ],
+        aud: w3sService.did(),
+          iss: w3sService.did()
+    },
+    type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
+    ts: Date.now()
+  }]
+
+  // @ts-expect-error not expecting type with just `aggregate/accept`
+  await updateAggregateAcceptTotal(invocations, {
+    workflowStore,
+    filecoinMetricsStore
+  })
+
+  const aggregateOfferTotal = await getItemFromTable(t.context.dynamoClient, tableName, {
+    name: METRICS_NAMES.AGGREGATE_ACCEPT_TOTAL
+  })
+  t.truthy(aggregateOfferTotal)
+  t.is(aggregateOfferTotal?.name, METRICS_NAMES.AGGREGATE_ACCEPT_TOTAL)
+  t.is(aggregateOfferTotal?.value, invocations.length)
+})
+
+test('handles a batch of single invocation with aggregate/accept', async t => {
+  const { tableName, bucketName } = await prepareResources(t.context.dynamoClient, t.context.s3)
+
+  // Context
+  const filecoinMetricsStore = createFilecoinMetricsTable(REGION, tableName, {
+    endpoint: t.context.dbEndpoint
+  })
+  const workflowStore = createWorkflowStore(REGION, bucketName, t.context.s3Opts)
+
+  // Invocation ctx
+  const w3sService = await Signer.generate()
+  const car = await randomCAR(128)
+
+  // Generate aggregate for test
+  const { pieces, aggregate } = await randomAggregate(100, 128)
+  const offer = pieces.map((p) => p.link)
+      const piecesBlock = await CBOR.write(offer)
+
+  const invocations = [{
+    carCid: car.cid.toString(),
+    value: {
+        att: [
+          DealerCapabilities.aggregateAccept.create({
+            with: w3sService.did(),
+            nb: {
+              aggregate: aggregate.link,
+              pieces: piecesBlock.cid,
+            }
+          })
+        ],
+        aud: w3sService.did(),
+          iss: w3sService.did()
+    },
+    type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
+    ts: Date.now()
+  }]
+
+  // @ts-expect-error not expecting type with just `aggregate/accept`
+  await updateAggregateAcceptTotal(invocations, {
+    workflowStore,
+    filecoinMetricsStore
+  })
+
+  const aggregateOfferTotal = await getItemFromTable(t.context.dynamoClient, tableName, {
+    name: METRICS_NAMES.AGGREGATE_ACCEPT_TOTAL
+  })
+  t.truthy(aggregateOfferTotal)
+  t.is(aggregateOfferTotal?.name, METRICS_NAMES.AGGREGATE_ACCEPT_TOTAL)
+  t.is(aggregateOfferTotal?.value, invocations.length)
+})
+
+test('handles a batch of single invocation without aggregate/accept', async t => {
+  const { tableName, bucketName } = await prepareResources(t.context.dynamoClient, t.context.s3)
+
+  // Context
+  const filecoinMetricsStore = createFilecoinMetricsTable(REGION, tableName, {
+    endpoint: t.context.dbEndpoint
+  })
+  const workflowStore = createWorkflowStore(REGION, bucketName, t.context.s3Opts)
+
+  // Invocation ctx
+  const uploadService = await Signer.generate()
+  const alice = await Signer.generate()
+  const { spaceDid } = await createSpace(alice)
+  const car = await randomCAR(128)
+
+  const invocations = [{
+    carCid: car.cid.toString(),
+    value: {
+        att: [
+          StoreCapabilities.remove.create({
+            with: spaceDid,
+            nb: {
+              link: car.cid,
+            }
+          })
+        ],
+        aud: uploadService.did(),
+        iss: alice.did()
+    },
+    type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
+    ts: Date.now()
+  }]
+
+  // @ts-expect-error not expecting type with just `aggregate/accept`
+  await updateAggregateAcceptTotal(invocations, {
+    workflowStore,
+    filecoinMetricsStore
+  })
+
+  const aggregateOfferTotal = await getItemFromTable(t.context.dynamoClient, tableName, {
+    name: METRICS_NAMES.AGGREGATE_ACCEPT_TOTAL
+  })
+  t.truthy(aggregateOfferTotal)
+  t.is(aggregateOfferTotal?.name, METRICS_NAMES.AGGREGATE_ACCEPT_TOTAL)
+  t.is(aggregateOfferTotal?.value, 0)
+})
+
+test('handles a batch of single invocation with aggregate/accept without receipts', async t => {
+  const { tableName, bucketName } = await prepareResources(t.context.dynamoClient, t.context.s3)
+
+  // Context
+  const filecoinMetricsStore = createFilecoinMetricsTable(REGION, tableName, {
+    endpoint: t.context.dbEndpoint
+  })
+  const workflowStore = createWorkflowStore(REGION, bucketName, t.context.s3Opts)
+
+  // Invocation ctx
+  const w3sService = await Signer.generate()
+  const car = await randomCAR(128)
+
+  // Generate aggregate for test
+  const { pieces, aggregate } = await randomAggregate(100, 128)
+  const offer = pieces.map((p) => p.link)
+      const piecesBlock = await CBOR.write(offer)
+
+  const invocations = [{
+    carCid: car.cid.toString(),
+    value: {
+        att: [
+          DealerCapabilities.aggregateAccept.create({
+            with: w3sService.did(),
+            nb: {
+              aggregate: aggregate.link,
+              pieces: piecesBlock.cid,
+            }
+          })
+        ],
+        aud: w3sService.did(),
+          iss: w3sService.did()
+    },
+    type: STREAM_TYPE.WORKFLOW,
+    out: {
+      ok: true
+    },
+    ts: Date.now()
+  }]
+
+  // @ts-expect-error not expecting type with just `aggregate/accept`
+  await updateAggregateAcceptTotal(invocations, {
+    workflowStore,
+    filecoinMetricsStore
+  })
+
+  const aggregateOfferTotal = await getItemFromTable(t.context.dynamoClient, tableName, {
+    name: METRICS_NAMES.AGGREGATE_ACCEPT_TOTAL
+  })
+  t.truthy(aggregateOfferTotal)
+  t.is(aggregateOfferTotal?.name, METRICS_NAMES.AGGREGATE_ACCEPT_TOTAL)
+  t.is(aggregateOfferTotal?.value, 0)
+})
+
+/**
+ * @param {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamoClient
+ * @param {import('@aws-sdk/client-s3').S3Client} s3Client
+ */
+async function prepareResources (dynamoClient, s3Client) {
+  const [ tableName, bucketName ] = await Promise.all([
+    createDynamoTable(dynamoClient, adminMetricsTableProps),
+    createBucket(s3Client)
+  ])
+
+  return {
+    bucketName,
+    tableName
+  }
+}

--- a/ucan-invocation/test/functions/metrics-aggregate-offer-total.test.js
+++ b/ucan-invocation/test/functions/metrics-aggregate-offer-total.test.js
@@ -1,0 +1,365 @@
+import { testConsumerWithBucket as test } from '../helpers/context.js'
+
+import { CBOR, CAR } from '@ucanto/core'
+import * as Signer from '@ucanto/principal/ed25519'
+import * as DealerCapabilities from '@web3-storage/capabilities/filecoin/dealer'
+import * as StoreCapabilities from '@web3-storage/capabilities/store'
+import { randomAggregate } from '@web3-storage/filecoin-api/test'
+import { PutObjectCommand } from '@aws-sdk/client-s3'
+import { Piece } from '@web3-storage/data-segment'
+
+import { updateAggregateOfferTotal } from '../../filecoin.js'
+
+import { adminMetricsTableProps } from '../../tables/index.js'
+import { createFilecoinMetricsTable } from '../../stores/filecoin-metrics.js'
+import { createWorkflowStore } from '../../buckets/workflow-store.js'
+import { METRICS_NAMES, STREAM_TYPE } from '../../constants.js'
+
+import {
+  createDynamodDb,
+  createS3,
+  createBucket,
+} from '../helpers/resources.js'
+import { randomCAR } from '../helpers/random.js'
+import { createDynamoTable, getItemFromTable} from '../helpers/tables.js'
+import { encodeAgentMessage, createSpace } from '../helpers/ucanto.js'
+
+const REGION = 'us-west-2'
+
+/**
+ * @typedef {import('@web3-storage/data-segment').PieceLink} PieceLink
+ * @typedef {import('@web3-storage/data-segment').AggregateView} AggregateView
+ */
+
+test.before(async t => {
+  // Dynamo DB
+  const {
+    client: dynamo,
+    endpoint: dbEndpoint
+  } = await createDynamodDb({ port: 8000 })
+  t.context.dbEndpoint = dbEndpoint
+  t.context.dynamoClient = dynamo
+
+  // S3
+  const { client, clientOpts } = await createS3()
+  t.context.s3 = client
+  t.context.s3Opts = clientOpts
+})
+
+test('handles a batch of single invocation with aggregate/offer', async t => {
+  const { tableName, bucketName } = await prepareResources(t.context.dynamoClient, t.context.s3)
+
+  // Context
+  const filecoinMetricsStore = createFilecoinMetricsTable(REGION, tableName, {
+    endpoint: t.context.dbEndpoint
+  })
+  const workflowStore = createWorkflowStore(REGION, bucketName, t.context.s3Opts)
+
+  // Generate aggregate for test
+  const { pieces, aggregate } = await randomAggregate(100, 128)
+  const aggregateOffers = [{ pieces, aggregate }]
+  const workflows = [aggregateOffers]
+
+  // Get UCAN Stream Invocations
+  const ucanStreamInvocations = await prepareUcanStream(workflows, {
+    bucketName,
+    s3: t.context.s3
+  })
+
+  // @ts-expect-error not expecting type with just `aggregate/offer`
+  await updateAggregateOfferTotal(ucanStreamInvocations, {
+    workflowStore,
+    filecoinMetricsStore
+  })
+
+  // Validate metrics
+  const aggregateOfferTotal = await getItemFromTable(t.context.dynamoClient, tableName, {
+    name: METRICS_NAMES.AGGREGATE_OFFER_TOTAL
+  })
+  t.truthy(aggregateOfferTotal)
+  t.is(aggregateOfferTotal?.name, METRICS_NAMES.AGGREGATE_OFFER_TOTAL)
+  t.is(aggregateOfferTotal?.value, aggregateOffers.length)
+
+  const aggregateOfferPiecesTotal = await getItemFromTable(t.context.dynamoClient, tableName, {
+    name: METRICS_NAMES.AGGREGATE_OFFER_PIECES_TOTAL
+  })
+  t.truthy(aggregateOfferPiecesTotal)
+  t.is(aggregateOfferPiecesTotal?.name, METRICS_NAMES.AGGREGATE_OFFER_PIECES_TOTAL)
+  t.is(aggregateOfferPiecesTotal?.value, pieces.length)
+
+  const piecesSize = pieces.reduce((acc, p) => {
+    return acc + Piece.fromLink(p.link).size
+  }, 0n)
+
+  const aggregateOfferPiecesSizeTotal = await getItemFromTable(t.context.dynamoClient, tableName, {
+    name: METRICS_NAMES.AGGREGATE_OFFER_PIECES_SIZE_TOTAL
+  })
+  t.truthy(aggregateOfferPiecesSizeTotal)
+  t.is(aggregateOfferPiecesSizeTotal?.name, METRICS_NAMES.AGGREGATE_OFFER_PIECES_SIZE_TOTAL)
+  t.is(aggregateOfferPiecesSizeTotal?.value, Number(piecesSize))
+})
+
+test('handles a batch of single invocation with multiple aggregate/offer attributes', async t => {
+  const { tableName, bucketName } = await prepareResources(t.context.dynamoClient, t.context.s3)
+
+  // Context
+  const filecoinMetricsStore = createFilecoinMetricsTable(REGION, tableName, {
+    endpoint: t.context.dbEndpoint
+  })
+  const workflowStore = createWorkflowStore(REGION, bucketName, t.context.s3Opts)
+
+  // Generate aggregate for test
+  const aggregateOffers = await Promise.all([
+    randomAggregate(50, 128),
+    randomAggregate(50, 128)
+  ])
+  const workflows = [aggregateOffers]
+
+  // Get UCAN Stream Invocations
+  const ucanStreamInvocations = await prepareUcanStream(workflows, {
+    bucketName,
+    s3: t.context.s3
+  })
+
+  // @ts-expect-error not expecting type with just `aggregate/offer`
+  await updateAggregateOfferTotal(ucanStreamInvocations, {
+    workflowStore,
+    filecoinMetricsStore
+  })
+
+  // Validate metrics
+  const aggregateOfferTotal = await getItemFromTable(t.context.dynamoClient, tableName, {
+    name: METRICS_NAMES.AGGREGATE_OFFER_TOTAL
+  })
+  t.truthy(aggregateOfferTotal)
+  t.is(aggregateOfferTotal?.name, METRICS_NAMES.AGGREGATE_OFFER_TOTAL)
+  t.is(aggregateOfferTotal?.value, aggregateOffers.length)
+
+  const aggregateOfferPiecesTotal = await getItemFromTable(t.context.dynamoClient, tableName, {
+    name: METRICS_NAMES.AGGREGATE_OFFER_PIECES_TOTAL
+  })
+  t.truthy(aggregateOfferPiecesTotal)
+  t.is(aggregateOfferPiecesTotal?.name, METRICS_NAMES.AGGREGATE_OFFER_PIECES_TOTAL)
+  t.is(aggregateOfferPiecesTotal?.value, aggregateOffers.reduce((acc, ao) => {
+    return acc + ao.pieces.length
+  }, 0))
+
+  const piecesSize = aggregateOffers.reduce((acc, ao) => {
+    return acc + ao.pieces.reduce((acc, p) => {
+      return acc + Piece.fromLink(p.link).size
+    }, 0n)
+  }, 0n)
+
+  const aggregateOfferPiecesSizeTotal = await getItemFromTable(t.context.dynamoClient, tableName, {
+    name: METRICS_NAMES.AGGREGATE_OFFER_PIECES_SIZE_TOTAL
+  })
+  t.truthy(aggregateOfferPiecesSizeTotal)
+  t.is(aggregateOfferPiecesSizeTotal?.name, METRICS_NAMES.AGGREGATE_OFFER_PIECES_SIZE_TOTAL)
+  t.is(aggregateOfferPiecesSizeTotal?.value, Number(piecesSize))
+})
+
+test('handles a batch of multiple invocations with single aggregate/offer attribute', async t => {
+  const { tableName, bucketName } = await prepareResources(t.context.dynamoClient, t.context.s3)
+
+  // Context
+  const filecoinMetricsStore = createFilecoinMetricsTable(REGION, tableName, {
+    endpoint: t.context.dbEndpoint
+  })
+  const workflowStore = createWorkflowStore(REGION, bucketName, t.context.s3Opts)
+
+  // Generate aggregate for test
+  const aggregateOffers = await Promise.all([
+    randomAggregate(50, 128),
+    randomAggregate(50, 128)
+  ])
+  const workflows = aggregateOffers.map(ao => [ao])
+
+  // Get UCAN Stream Invocations
+  const ucanStreamInvocations = await prepareUcanStream(workflows, {
+    bucketName,
+    s3: t.context.s3
+  })
+
+  // @ts-expect-error not expecting type with just `aggregate/offer`
+  await updateAggregateOfferTotal(ucanStreamInvocations, {
+    workflowStore,
+    filecoinMetricsStore
+  })
+
+  // Validate metrics
+  const aggregateOfferTotal = await getItemFromTable(t.context.dynamoClient, tableName, {
+    name: METRICS_NAMES.AGGREGATE_OFFER_TOTAL
+  })
+  t.truthy(aggregateOfferTotal)
+  t.is(aggregateOfferTotal?.name, METRICS_NAMES.AGGREGATE_OFFER_TOTAL)
+  t.is(aggregateOfferTotal?.value, aggregateOffers.length)
+
+  const aggregateOfferPiecesTotal = await getItemFromTable(t.context.dynamoClient, tableName, {
+    name: METRICS_NAMES.AGGREGATE_OFFER_PIECES_TOTAL
+  })
+  t.truthy(aggregateOfferPiecesTotal)
+  t.is(aggregateOfferPiecesTotal?.name, METRICS_NAMES.AGGREGATE_OFFER_PIECES_TOTAL)
+  t.is(aggregateOfferPiecesTotal?.value, aggregateOffers.reduce((acc, ao) => {
+    return acc + ao.pieces.length
+  }, 0))
+
+  const piecesSize = aggregateOffers.reduce((acc, ao) => {
+    return acc + ao.pieces.reduce((acc, p) => {
+      return acc + Piece.fromLink(p.link).size
+    }, 0n)
+  }, 0n)
+
+  const aggregateOfferPiecesSizeTotal = await getItemFromTable(t.context.dynamoClient, tableName, {
+    name: METRICS_NAMES.AGGREGATE_OFFER_PIECES_SIZE_TOTAL
+  })
+  t.truthy(aggregateOfferPiecesSizeTotal)
+  t.is(aggregateOfferPiecesSizeTotal?.name, METRICS_NAMES.AGGREGATE_OFFER_PIECES_SIZE_TOTAL)
+  t.is(aggregateOfferPiecesSizeTotal?.value, Number(piecesSize))
+})
+
+test('handles a batch of single invocation without aggregate/offer', async t => {
+  const { tableName, bucketName } = await prepareResources(t.context.dynamoClient, t.context.s3)
+
+  // Context
+  const filecoinMetricsStore = createFilecoinMetricsTable(REGION, tableName, {
+    endpoint: t.context.dbEndpoint
+  })
+  const workflowStore = createWorkflowStore(REGION, bucketName, t.context.s3Opts)
+
+  // Get unrelated invocation
+  const uploadService = await Signer.generate()
+  const car = await randomCAR(128)
+  const alice = await Signer.generate()
+  const { spaceDid } = await createSpace(alice)
+
+  const ucanStreamInvocations = [{
+    carCid: car.cid.toString(),
+    value: {
+        att: [
+          StoreCapabilities.add.create({
+            with: spaceDid,
+            nb: {
+              link: car.cid,
+              size: car.size
+            }
+          })
+        ],
+        aud: uploadService.did(),
+        iss: alice.did()
+    },
+    type: STREAM_TYPE.RECEIPT,
+    out: {
+      ok: true
+    },
+    ts: Date.now()
+  }]
+
+  // @ts-expect-error not expecting type with just `aggregate/offer`
+  await updateAggregateOfferTotal(ucanStreamInvocations, {
+    workflowStore,
+    filecoinMetricsStore
+  })
+
+  // Validate metrics
+  const aggregateOfferTotal = await getItemFromTable(t.context.dynamoClient, tableName, {
+    name: METRICS_NAMES.AGGREGATE_OFFER_TOTAL
+  })
+  t.truthy(aggregateOfferTotal)
+  t.is(aggregateOfferTotal?.name, METRICS_NAMES.AGGREGATE_OFFER_TOTAL)
+  t.is(aggregateOfferTotal?.value, 0)
+
+  const aggregateOfferPiecesTotal = await getItemFromTable(t.context.dynamoClient, tableName, {
+    name: METRICS_NAMES.AGGREGATE_OFFER_PIECES_TOTAL
+  })
+  t.truthy(aggregateOfferPiecesTotal)
+  t.is(aggregateOfferPiecesTotal?.name, METRICS_NAMES.AGGREGATE_OFFER_PIECES_TOTAL)
+  t.is(aggregateOfferPiecesTotal?.value, 0)
+
+  const aggregateOfferPiecesSizeTotal = await getItemFromTable(t.context.dynamoClient, tableName, {
+    name: METRICS_NAMES.AGGREGATE_OFFER_PIECES_SIZE_TOTAL
+  })
+  t.truthy(aggregateOfferPiecesSizeTotal)
+  t.is(aggregateOfferPiecesSizeTotal?.name, METRICS_NAMES.AGGREGATE_OFFER_PIECES_SIZE_TOTAL)
+  t.is(aggregateOfferPiecesSizeTotal?.value, 0)
+})
+
+/**
+ * @param {{pieces: { link: PieceLink }[], aggregate: AggregateView }[][]} workflows
+ * @param {{ bucketName: string, s3: import('@aws-sdk/client-s3').S3Client }} ctx
+ */
+async function prepareUcanStream (workflows, ctx) {
+  const w3sService = await Signer.generate()
+
+  return Promise.all(workflows.map(async aggregateOffers => {
+    const invocationsToExecute = await Promise.all(aggregateOffers.map(async agg => {
+      const offer = agg.pieces.map((p) => p.link)
+      const piecesBlock = await CBOR.write(offer)
+
+      // Create UCAN invocation workflow
+      const invocationParameters = {
+        aggregate: agg.aggregate.link,
+        pieces: piecesBlock.cid,
+      }
+      const invocation = DealerCapabilities.aggregateOffer.invoke({
+        issuer: w3sService,
+        audience: w3sService,
+        with: w3sService.did(),
+        nb: invocationParameters
+      })
+      invocation.attach(piecesBlock)
+
+      return {
+        invocation,
+        params: invocationParameters
+      }
+    }))
+
+    const request = await encodeAgentMessage({ invocations: invocationsToExecute.map(ie => ie.invocation) })
+    const body = new Uint8Array(request.body.buffer)
+    // Decode request to get CAR CID
+    const decodedCar = CAR.decode(body)
+    const agentMessageCarCid = decodedCar.roots[0].cid.toString()
+
+    // Store UCAN invocation workflow
+    const putObjectCmd = new PutObjectCommand({
+      Key: `${agentMessageCarCid}/${agentMessageCarCid}`,
+      Bucket: ctx.bucketName,
+      Body: body
+    })
+    await ctx.s3.send(putObjectCmd)
+
+    // Create UCAN Stream Invocation
+    return {
+      carCid: agentMessageCarCid,
+      value: {
+          att: invocationsToExecute.map(ie => DealerCapabilities.aggregateOffer.create({
+            with: w3sService.did(),
+            nb: ie.params
+          })),
+          aud: w3sService.did(),
+          iss: w3sService.did()
+      },
+      type: STREAM_TYPE.RECEIPT,
+      out: {
+        ok: true
+      },
+      ts: Date.now()
+    }
+  }))
+}
+
+/**
+ * @param {import('@aws-sdk/client-dynamodb').DynamoDBClient} dynamoClient
+ * @param {import('@aws-sdk/client-s3').S3Client} s3Client
+ */
+async function prepareResources (dynamoClient, s3Client) {
+  const [ tableName, bucketName ] = await Promise.all([
+    createDynamoTable(dynamoClient, adminMetricsTableProps),
+    createBucket(s3Client)
+  ])
+
+  return {
+    bucketName,
+    tableName
+  }
+}

--- a/ucan-invocation/test/helpers/ucanto.js
+++ b/ucan-invocation/test/helpers/ucanto.js
@@ -1,5 +1,14 @@
+import { Message } from '@ucanto/core'
+import * as CAR from '@ucanto/transport/car'
 import * as UcantoClient from '@ucanto/client'
 import * as Signer from '@ucanto/principal/ed25519'
+
+/**
+ * @typedef {import('@ucanto/interface').IssuedInvocation} IssuedInvocation
+ * @typedef {import('@ucanto/interface').Receipt} Receipt
+ * @typedef {import('@ucanto/interface').Tuple<Receipt>} TupleReceipt
+ * @typedef {import('@ucanto/interface').Tuple<IssuedInvocation>} TupleIssuedInvocation
+ */
 
 /**
  * @param {import('@ucanto/interface').Principal} audience
@@ -16,4 +25,20 @@ export async function createSpace (audience) {
     }),
     spaceDid
   }
+}
+
+/**
+ * @param {object} source
+ * @param {IssuedInvocation[]} [source.invocations]
+ * @param {Receipt[]} [source.receipts]
+ */
+export const encodeAgentMessage = async (source) => {
+  const message = await Message.build({
+    invocations: /** @type {TupleIssuedInvocation} */ (
+      source.invocations
+    ),
+    receipts: /** @type {TupleReceipt} */ (source.receipts),
+  })
+
+  return CAR.request.encode(message)
 }

--- a/ucan-invocation/types.ts
+++ b/ucan-invocation/types.ts
@@ -2,6 +2,16 @@ import type { DID, Link } from '@ucanto/interface'
 import { ToString, UnknownLink } from 'multiformats'
 import { Ability, Capability, Capabilities } from '@ucanto/interface'
 
+export interface FilecoinMetricsStore {
+  incrementTotal: (metricName: string, n: number) => Promise<void>
+  incrementTotals: (metricsToUpdate: Record<string, number>) => Promise<void>
+}
+
+export interface FilecoinMetricsCtx {
+  filecoinMetricsStore: FilecoinMetricsStore
+  workflowStore: WorkflowBucket
+}
+
 export interface MetricsTable {
   incrementStoreAddTotal: (incrementSizeTotal: Capability<Ability, `${string}:${string}`, unknown>[]) => Promise<void>
   incrementStoreAddSizeTotal: (incrementSizeTotal: Capability<Ability, `${string}:${string}`, unknown>[]) => Promise<void>
@@ -13,6 +23,10 @@ export interface MetricsTable {
 
 export interface CarStoreBucket {
   getSize: (link: UnknownLink) => Promise<number>
+}
+
+export interface WorkflowBucket {
+  get: (Cid: string) => Promise<Uint8Array|undefined>
 }
 
 export interface TotalSizeCtx {
@@ -48,6 +62,7 @@ export type UcanInvocationType = 'workflow' | 'receipt'
 
 export interface UcanInvocation {
   carCid: string
+  invocationCid: string
   value: UcanInvocationValue
   ts: number
   type: UcanInvocationType
@@ -55,9 +70,9 @@ export interface UcanInvocation {
 }
 
 export interface UcanInvocationValue {
-  att: Capabilities,
-  aud: DID,
-  iss?: DID,
+  att: Capabilities
+  aud: DID
+  iss?: DID
   prf?: LinkJSON<Link>[]
 }
 

--- a/upload-api/functions/metrics.js
+++ b/upload-api/functions/metrics.js
@@ -6,7 +6,9 @@ import {
   STORE_ADD,
   STORE_REMOVE,
   UPLOAD_ADD,
-  UPLOAD_REMOVE
+  UPLOAD_REMOVE,
+  AGGREGATE_OFFER,
+  AGGREGATE_ACCEPT
 } from '@web3-storage/w3infra-ucan-invocation/constants.js'
 
 import { createMetricsTable } from '../tables/metrics.js'
@@ -71,12 +73,22 @@ export async function recordMetrics (metrics, metricsTable) {
   metrics.invocations.inc({ 'can': STORE_REMOVE }, fetchedMetrics[METRICS_NAMES.STORE_REMOVE_TOTAL] || 0)
   metrics.invocations.inc({ 'can': UPLOAD_ADD }, fetchedMetrics[METRICS_NAMES.UPLOAD_ADD_TOTAL] || 0)
   metrics.invocations.inc({ 'can': UPLOAD_REMOVE }, fetchedMetrics[METRICS_NAMES.UPLOAD_REMOVE_TOTAL] || 0)
+
+  // aggregates count
+  metrics.aggregates.inc({ 'can': AGGREGATE_OFFER }, fetchedMetrics[METRICS_NAMES.AGGREGATE_OFFER_TOTAL] || 0)
+  metrics.aggregates.inc({ 'can': AGGREGATE_ACCEPT }, fetchedMetrics[METRICS_NAMES.AGGREGATE_ACCEPT_TOTAL] || 0)
+
+  metrics.aggregatedPieces.inc({ 'can': AGGREGATE_OFFER }, fetchedMetrics[METRICS_NAMES.AGGREGATE_OFFER_PIECES_TOTAL] || 0)
+  metrics.aggregatedPiecesBytes.inc({ 'can': AGGREGATE_OFFER }, fetchedMetrics[METRICS_NAMES.AGGREGATE_OFFER_PIECES_SIZE_TOTAL] || 0)
 }
 
 /**
  * @typedef {object} Metrics
  * @property {Prom.Counter<'can'>} bytes
  * @property {Prom.Counter<'can'>} invocations
+ * @property {Prom.Counter<'can'>} aggregates
+ * @property {Prom.Counter<'can'>} aggregatedPieces
+ * @property {Prom.Counter<'can'>} aggregatedPiecesBytes
  */
 
 function createRegistry (ns = 'w3up') {
@@ -93,6 +105,24 @@ function createRegistry (ns = 'w3up') {
       invocations: new Prom.Counter({
         name: `${ns}_invocations_total`,
         help: 'Total number of invocations.',
+        labelNames: ['can'],
+        registers: [registry]
+      }),
+      aggregates: new Prom.Counter({
+        name: `${ns}_aggregates_total`,
+        help: 'Total number of aggregates.',
+        labelNames: ['can'],
+        registers: [registry]
+      }),
+      aggregatedPieces: new Prom.Counter({
+        name: `${ns}_aggregated_pieces_total`,
+        help: 'Total number of pieces aggregated.',
+        labelNames: ['can'],
+        registers: [registry]
+      }),
+      aggregatedPiecesBytes: new Prom.Counter({
+        name: `${ns}_aggregated_pieces_bytes`,
+        help: 'Total bytes of pieces aggregated.',
         labelNames: ['can'],
         registers: [registry]
       }),


### PR DESCRIPTION
Adds filecoin metrics for ucan stream in the same pattern we track other metrics in https://up.web3.storage/metrics

We want to rely on UCAN Stream metrics table to in a "prometheus style" increment metrics over time for totals.  There are some metrics in Firehose that we can rely on for ad-hoc queries and business queries (like monthly usage). More than the price and efficiency in the long run for totals in the Firehose, there are some limitations that are explicit here:

- we use PieceCids to encode Piece size, which we will never be able to handle in Athena level as we cannot decode the CID to get the size
- UCAN invocations (like aggregate/offer) may rely on attached blocks to move attachments with the invocation, while only identifying the CID for them. E.g in `aggregate/offer` we encode the very large list of pieces to put into the aggregate in a CBOR block, and inline it in the CAR of the invocation, while providing `pieces` as CID of the block in the nb object.

We will need most measures I wanted to handle, except for tracking execution time between the invocations. We need https://github.com/web3-storage/w3up/issues/970 to get the power to track execution time of a UCAN effect (e.g. time between receipt of `aggregate/offer` and `aggregate/accept`

