### PR TITLE
feat: glue query for hours to data commited over last 7 days

### DIFF
--- a/stacks/firehose-stack.js
+++ b/stacks/firehose-stack.js
@@ -865,12 +865,12 @@ ORDER BY upload_ts DESC
   // create a query that can be executed by going to 
   // https://console.aws.amazon.com/athena/home#/query-editor/saved-queries
   // and selecting the appropriate Workgroup from the dropdown in the upper right
-  const aggregateHoursToDealQueryName = getCdkNames('aggregate-hours-to-deal-query', app.stage)
-  const aggregateHoursToDealQuery = new athena.CfnNamedQuery(stack, aggregateHoursToDealQueryName, {
-    name: "Hours to deal per aggregate in the last 7 days",
+  const aggregateHoursToDataCommitedQueryName = getCdkNames('aggregate-hours-to-data-commited-query', app.stage)
+  const aggregateHoursToDataCommitedQuery = new athena.CfnNamedQuery(stack, aggregateHoursToDataCommitedQueryName, {
+    name: "Hours to data commited per aggregate in the last 7 days",
     description: `${app.stage} w3up preload
     
-Hours to deal per aggregate in the last 7 days`,
+Hours to data commited per aggregate in the last 7 days`,
     database: databaseName,
     workGroup: workgroupName,
     queryString: `WITH 
@@ -883,14 +883,14 @@ accepted_aggregates AS (
 SELECT cid,
        ts as offer_ts,
        accept_ts,
-       CAST((to_unixtime(accept_ts) - to_unixtime(ts))/3600 as integer) as hrs_deal
+       CAST((to_unixtime(accept_ts) - to_unixtime(ts))/3600 as integer) as hrs_to_data_commited
 FROM "AwsDataCatalog"."${databaseName}."${aggregateOfferTableName}"
 INNER JOIN accepted_aggregates ON accepted_aggregates.cid = value.att[1].nb.aggregate._cid_slash
 `
   })
-  aggregateHoursToDealQuery.addDependsOn(workgroup)
-  aggregateHoursToDealQuery.addDependsOn(aggregateAcceptTable)
-  aggregateHoursToDealQuery.addDependsOn(aggregateOfferTable)
+  aggregateHoursToDataCommitedQuery.addDependsOn(workgroup)
+  aggregateHoursToDataCommitedQuery.addDependsOn(aggregateAcceptTable)
+  aggregateHoursToDataCommitedQuery.addDependsOn(aggregateOfferTable)
 
   // configure the Athena Dynamo connector
 


### PR DESCRIPTION
Adds query to calculate hours to data commited of aggregates over last 7 days by seeing difference between time of `aggregate/offer` and `aggregate/accept` receipts.

You can copy query

```sql
WITH
accepted_aggregates AS (
SELECT value.att[1].nb.aggregate._cid_slash as cid, ts as accept_ts FROM "AwsDataCatalog"."prod-w3infra-ucan-stream-delivery-database-0"."prod-w3infra-aggregate-accept-table-0" WHERE ts >= (CURRENT_TIMESTAMP - INTERVAL '7' DAY)
)
select cid, ts as offer_ts, accept_ts, CAST((to_unixtime(accept_ts) - to_unixtime(ts))/3600 as integer)  as hours_to_data_commited FROM "AwsDataCatalog"."prod-w3infra-ucan-stream-delivery-database-0"."prod-w3infra-aggregate-offer-table-0" INNER JOIN accepted_aggregates ON accepted_aggregates.cid = value.att[1].nb.aggregate._cid_slash;
``` 

and put it in https://us-west-2.console.aws.amazon.com/athena/home?region=us-west-2#/query-editor/history/ffcc98f0-d243-4a57-b085-911fff8053d3 for running