### PR TITLE
feat!: adjust max upload size for more optimal Filecoin sector packing

### DIFF
--- a/upload-api/test/helpers/ucan.js
+++ b/upload-api/test/helpers/ucan.js
@@ -269,8 +269,10 @@ export async function executionContextToUcantoTestServerContext (t) {
     // The largest object that can be uploaded in a single PUT is 5 GB
     // https://aws.amazon.com/s3/faqs/
     // However, this would allow for only 5 shards per Filecoin sector (if all
-    // 5GB). 4GB would allow a minimum 7 shards per sector.
-    maxUploadSize: 4_261_412_864,
+    // 5GB). Slightly under 4GB would allow a minimum 7 shards per sector.
+    // ( Filecoin data is addressed in 127 byte increments with offsets
+    // thus the unusual 4GiB/128*127 value ) 
+    maxUploadSize: 4_261_412_864, 
     storeTable,
     uploadTable,
     carStoreBucket,

--- a/upload-api/test/helpers/ucan.js
+++ b/upload-api/test/helpers/ucan.js
@@ -266,7 +266,11 @@ export async function executionContextToUcantoTestServerContext (t) {
         t.fail(error.message);
       },
     },
-    maxUploadSize: 5_000_000_000,
+    // The largest object that can be uploaded in a single PUT is 5 GB
+    // https://aws.amazon.com/s3/faqs/
+    // However, this would allow for only 5 shards per Filecoin sector (if all
+    // 5GB). 4GB would allow a minimum 7 shards per sector.
+    maxUploadSize: 4_261_412_864,
     storeTable,
     uploadTable,
     carStoreBucket,


### PR DESCRIPTION
This PR alters the maximum upload size in bytes to allow for more optimal filecoin sector packing (7 shards vs 5).

Technically a breaking change but not something that will affect many users since the client default is to chunk to 128MB.

BREAKING CHANGE: max upload size is reduced.