### PR TITLE
fix: sort key for space diffs

### DIFF
--- a/billing/data/space-diff.js
+++ b/billing/data/space-diff.js
@@ -28,7 +28,7 @@ export const encode = input => {
     return {
       ok: {
         pk: `${input.provider}#${input.space}`,
-        sk: `${input.receiptAt}#${input.cause}`,
+        sk: `${input.receiptAt.toISOString()}#${input.cause}`,
         space: input.space,
         provider: input.provider,
         subscription: input.subscription,


### PR DESCRIPTION
🙈 🙈 🙈 

We currently have sort keys like:

```
Wed Nov 15 2023 16:23:16 GMT+0000 (Coordinated Universal Time)#bafyreiaaqkc6e2rcij7tipadffmqrdfcwbztcms3g7ayktyterfascn3xm
```

...which does not sort as expected