### PR TITLE
fix: restart filecoin metrics from w3up ship day

### DIFF
--- a/stacks/filecoin-stack.js
+++ b/stacks/filecoin-stack.js
@@ -11,8 +11,7 @@ import { BusStack } from './bus-stack.js'
 import { CarparkStack } from './carpark-stack.js'
 import { UploadDbStack } from './upload-db-stack.js'
 import { UcanInvocationStack } from './ucan-invocation-stack.js'
-// import { setupSentry, getEnv, getCdkNames, getCustomDomain, getEventSourceConfig } from './config.js'
-import { setupSentry, getEnv, getCdkNames, getCustomDomain } from './config.js'
+import { setupSentry, getEnv, getCdkNames, getCustomDomain, getEventSourceConfig } from './config.js'
 import { CARPARK_EVENT_BRIDGE_SOURCE_EVENT } from '../carpark/event-bus/source.js'
 import { Status } from '../filecoin/store/piece.js'
 
@@ -47,8 +46,7 @@ export function FilecoinStack({ stack, app }) {
   // Get store table reference
   const { pieceTable, privateKey, contentClaimsPrivateKey, adminMetricsTable } = use(UploadDbStack)
   // Get UCAN store references
-  // const { workflowBucket, invocationBucket, ucanStream } = use(UcanInvocationStack)
-  const { workflowBucket, invocationBucket } = use(UcanInvocationStack)
+  const { workflowBucket, invocationBucket, ucanStream } = use(UcanInvocationStack)
 
   /**
    * 1st processor queue - filecoin submit
@@ -301,8 +299,7 @@ export function FilecoinStack({ stack, app }) {
 
   // `aggregate/offer` + `aggregate-accept` metrics
   const metricsAggregateTotalDLQ = new Queue(stack, 'metrics-aggregate-total-dlq')
-  // const metricsAggregateTotalConsumer = new Function(stack, 'metrics-aggregate-total-consumer', {
-  new Function(stack, 'metrics-aggregate-total-consumer', {
+  const metricsAggregateTotalConsumer = new Function(stack, 'metrics-aggregate-total-consumer', {
     environment: {
       METRICS_TABLE_NAME: adminMetricsTable.tableName,
       WORKFLOW_BUCKET_NAME: workflowBucket.bucketName,
@@ -314,16 +311,16 @@ export function FilecoinStack({ stack, app }) {
     deadLetterQueue: metricsAggregateTotalDLQ.cdk.queue,
   })
 
-  // ucanStream.addConsumers(stack, {
-  //   metricsAggregateTotalConsumer: {
-  //     function: metricsAggregateTotalConsumer,
-  //     cdk: {
-  //       eventSource: {
-  //         ...(getEventSourceConfig(stack))
-  //       }
-  //     }
-  //   }
-  // })
+  ucanStream.addConsumers(stack, {
+    metricsAggregateTotalConsumer: {
+      function: metricsAggregateTotalConsumer,
+      cdk: {
+        eventSource: {
+          ...(getEventSourceConfig(stack))
+        }
+      }
+    }
+  })
 
   return {
     filecoinSubmitQueue,

--- a/upload-api/functions/metrics.js
+++ b/upload-api/functions/metrics.js
@@ -91,7 +91,7 @@ export async function recordMetrics (metrics, metricsTable) {
  * @property {Prom.Counter<'can'>} aggregatedPiecesBytes
  */
 
-function createRegistry (ns = 'w3up') {
+function createRegistry (ns = 'w3up', filecoinNs = 'w3filecoin') {
   const registry = new Prom.Registry()
   return {
     registry,
@@ -109,19 +109,19 @@ function createRegistry (ns = 'w3up') {
         registers: [registry]
       }),
       aggregates: new Prom.Counter({
-        name: `${ns}_aggregates_total`,
+        name: `${filecoinNs}_aggregates_total`,
         help: 'Total number of aggregates.',
         labelNames: ['can'],
         registers: [registry]
       }),
       aggregatedPieces: new Prom.Counter({
-        name: `${ns}_aggregated_pieces_total`,
+        name: `${filecoinNs}_aggregated_pieces_total`,
         help: 'Total number of pieces aggregated.',
         labelNames: ['can'],
         registers: [registry]
       }),
       aggregatedPiecesBytes: new Prom.Counter({
-        name: `${ns}_aggregated_pieces_bytes`,
+        name: `${filecoinNs}_aggregated_pieces_bytes`,
         help: 'Total bytes of pieces aggregated.',
         labelNames: ['can'],
         registers: [registry]


### PR DESCRIPTION
> We were counting aggregate offers before shipping w3up that in the end we reset state given the incident of upload spike of repeated data in multiple orders. 

See https://github.com/web3-storage/w3infra/pull/310 and https://github.com/web3-storage/w3infra/pull/311