### PR TITLE
fix: add bucket permissions to lambda

### DIFF
--- a/stacks/upload-api-stack.js
+++ b/stacks/upload-api-stack.js
@@ -143,7 +143,7 @@ export function UploadApiStack({ stack, app }) {
       ADMIN_METRICS_TABLE_NAME: adminMetricsTable.tableName,
       STORE_BUCKET_NAME: carparkBucket.bucketName,
     },
-    permissions: [adminMetricsTable],
+    permissions: [adminMetricsTable, carparkBucket],
     handler: 'functions/admin-metrics.consumer',
     deadLetterQueue: uploadAdminMetricsDLQ.cdk.queue,
   })
@@ -154,7 +154,7 @@ export function UploadApiStack({ stack, app }) {
       SPACE_METRICS_TABLE_NAME: spaceMetricsTable.tableName,
       STORE_BUCKET_NAME: carparkBucket.bucketName,
     },
-    permissions: [spaceMetricsTable],
+    permissions: [spaceMetricsTable, carparkBucket],
     handler: 'functions/space-metrics.consumer',
     deadLetterQueue: uploadSpaceMetricsDLQ.cdk.queue,
   })


### PR DESCRIPTION
It happened 5 days ago this deploy, so the failures that happened will still luckily be processed 

also: we check the metrics in the integration tests, I have no idea on how in staging it was working fine :exploding_head: 