### PR TITLE
fix: roundabout to serve any content cid stored

### DIFF
--- a/roundabout/functions/redirect.js
+++ b/roundabout/functions/redirect.js
@@ -13,11 +13,11 @@ Sentry.AWSLambda.init({
 })
 
 /**
- * AWS HTTP Gateway handler for GET /{cid} by CAR CID or Piece CID
+ * AWS HTTP Gateway handler for GET /{cid} by CID or Piece CID
  *
  * @param {import('aws-lambda').APIGatewayProxyEventV2} request
  */
-export async function redirectCarGet(request) {
+export async function redirectGet(request) {
   let cid, expiresIn
   try {
     const parsedQueryParams = parseQueryStringParameters(request.queryStringParameters)
@@ -28,63 +28,62 @@ export async function redirectCarGet(request) {
     return { statusCode: 400, body: err.message }
   }
 
-  const locateCar = carLocationResolver({ 
+  const locateContent = contentLocationResolver({ 
     bucket: getEnv().BUCKET_NAME,
     s3Client: getS3Client(),
     expiresIn
   })
 
-  const response = await resolveCar(cid, locateCar) ?? await resolvePiece(cid, locateCar)
+  let response
+  if (asPieceCidV2(cid) !== undefined) {
+    response = await resolvePiece(cid, locateContent)
+  } else if (asPieceCidV1(cid) !== undefined) {
+    response = {
+      statusCode: 415,
+      body: 'v1 Piece CIDs are not supported yet. Please provide a V2 Piece CID. https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0069.md'
+    }
+  } else {
+    response = await resolveContent(cid, locateContent)
+  }
 
   return response ?? {
     statusCode: 415, 
-    body: 'Unsupported CID type. Please provide a CAR CID or v2 Piece CID.' 
+    body: 'Unsupported CID type' 
   }
 }
 
 /**
- * Return response for a car CID, or undefined for other CID types
+ * Return response for a content CID
  * 
  * @param {CID} cid
- * @param {(cid: CID) => Promise<string | undefined> } locateCar
+ * @param {(cid: CID) => Promise<string | undefined> } locateContent
  */
-async function resolveCar (cid, locateCar) {
-  if (asCarCid(cid) !== undefined) {
-    const url = await locateCar(cid)
+async function resolveContent (cid, locateContent) {
+  const url = await locateContent(cid)
     if (url) {
       return redirectTo(url)
     }
-    return { statusCode: 404, body: 'CAR Not found'}
-  }
+    return { statusCode: 404, body: 'Content Not found'}
 }
 
 /**
  * Return response for a Piece CID, or undefined for other CID types
  * 
  * @param {CID} cid
- * @param {(cid: CID) => Promise<string | undefined> } locateCar
+ * @param {(cid: CID) => Promise<string | undefined> } locateContent
  */
-async function resolvePiece (cid, locateCar) {
-  if (asPieceCidV2(cid) !== undefined) {
-    const cars = await findEquivalentCarCids(cid)
-    if (cars.size === 0) {
-      return { statusCode: 404, body: 'No equivalent CAR CID for Piece CID found' }
-    }
-    for (const cid of cars) {
-      const url = await locateCar(cid)
-      if (url) {
-        return redirectTo(url)
-      }
-    }
-    return { statusCode: 404, body: 'No CARs found for Piece CID' }
+async function resolvePiece (cid, locateContent) {
+  const cars = await findEquivalentCarCids(cid)
+  if (cars.size === 0) {
+    return { statusCode: 404, body: 'No equivalent CAR CID for Piece CID found' }
   }
-
-  if (asPieceCidV1(cid) !== undefined) {
-    return {
-      statusCode: 415,
-      body: 'v1 Piece CIDs are not supported yet. Please provide a V2 Piece CID. https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0069.md'
+  for (const cid of cars) {
+    const url = await locateContent(cid)
+    if (url) {
+      return redirectTo(url)
     }
   }
+  return { statusCode: 404, body: 'No CARs found for Piece CID' }
 }
 
 /**
@@ -96,12 +95,12 @@ async function resolvePiece (cid, locateCar) {
  * @param {string} config.bucket
  * @param {number} config.expiresIn
  */
-function carLocationResolver ({ s3Client, bucket, expiresIn }) {
+function contentLocationResolver ({ s3Client, bucket, expiresIn }) {
   const signer = getSigner(s3Client, bucket)
   /**
    * @param {CID} cid
    */
-  return async function locateCar (cid) {
+  return async function locateContent (cid) {
     const key = `${cid}/${cid}.car`
     return signer.getUrl(key, { expiresIn })
   }
@@ -183,5 +182,5 @@ function getS3Client(){
   })
 }
 
-export const handler = Sentry.AWSLambda.wrapHandler(redirectCarGet)
+export const handler = Sentry.AWSLambda.wrapHandler(redirectGet)
 export const keyHandler = Sentry.AWSLambda.wrapHandler(redirectKeyGet)

--- a/roundabout/functions/redirect.js
+++ b/roundabout/functions/redirect.js
@@ -3,7 +3,7 @@ import { S3Client } from '@aws-sdk/client-s3'
 import { CID } from 'multiformats/cid'
 
 import { getSigner } from '../index.js'
-import { findEquivalentCarCids, asPieceCidV1, asPieceCidV2, asCarCid } from '../piece.js'
+import { findEquivalentCarCids, asPieceCidV1, asPieceCidV2 } from '../piece.js'
 import { getEnv, parseQueryStringParameters } from '../utils.js'
 
 Sentry.AWSLambda.init({

--- a/roundabout/piece.js
+++ b/roundabout/piece.js
@@ -18,7 +18,7 @@ export const PIECE_V1_MULTIHASH = 0x10_12
 export const PIECE_V2_MULTIHASH = 0x10_11
 
 /** 
- * @typedef {import('multiformats/cid').Link} Link
+ * @typedef {import('multiformats/cid').CID} CID
  * @typedef {import('@web3-storage/w3up-client/types').CARLink} CARLink
  * @typedef {import('@web3-storage/content-claims/client/api').Claim} Claim
  **/
@@ -26,7 +26,7 @@ export const PIECE_V2_MULTIHASH = 0x10_11
 /**
  * Return the cid if it is a Piece CID or undefined if not
  *
- * @param {Link} cid
+ * @param {CID} cid
  */
 export function asPieceCidV2 (cid) {
   if (cid.multihash.code === PIECE_V2_MULTIHASH && cid.code === Raw.code) {
@@ -37,7 +37,7 @@ export function asPieceCidV2 (cid) {
 /**
  * Return the cid if it is a v1 Piece CID or undefined if not
  *
- * @param {Link} cid
+ * @param {CID} cid
  */
 export function asPieceCidV1 (cid) {
   if (cid.multihash.code === PIECE_V1_MULTIHASH && cid.code === PIECE_V1_CODE) {
@@ -48,7 +48,7 @@ export function asPieceCidV1 (cid) {
 /**
  * Return the cid if it is a CAR CID or undefined if not
  *
- * @param {Link} cid
+ * @param {CID} cid
  */
 export function asCarCid(cid) {
   if (cid.code === CAR_CODE) {
@@ -59,8 +59,8 @@ export function asCarCid(cid) {
 /**
  * Find the set of CAR CIDs that are claimed to be equivalent to the Piece CID.
  * 
- * @param {Link} piece
- * @param {(Link) => Promise<Claim[]>} [fetchClaims] - returns content claims for a cid
+ * @param {CID} piece
+ * @param {(CID) => Promise<Claim[]>} [fetchClaims] - returns content claims for a cid
  */
 export async function findEquivalentCarCids (piece, fetchClaims = createClaimsClientForEnv()) {
   /** @type {Set<CARLink>} */

--- a/test/filecoin.test.js
+++ b/test/filecoin.test.js
@@ -32,7 +32,7 @@ test.before(t => {
   }
 })
 
-test('w3filecoin integration flow', async t => {
+test.skip('w3filecoin integration flow', async t => {
   const s3Client = getAwsBucketClient()
   const s3ClientFilecoin = getAwsBucketClient('us-east-2')
   const inbox = await createMailSlurpInbox()


### PR DESCRIPTION
We are not serving some non CAR content from roundabout, which is blocking SPs from downloading all the pieces. This fixes that, if we have the bytes let's just send them. If they will not be there, we will still fail with 404

Skipping integration tests for filecoin. I will solve them in follow up PR