### PR TITLE
fix: find equivalent cids also if not car cid

### DIFF
--- a/roundabout/functions/redirect.js
+++ b/roundabout/functions/redirect.js
@@ -3,7 +3,7 @@ import { S3Client } from '@aws-sdk/client-s3'
 import { CID } from 'multiformats/cid'
 
 import { getSigner } from '../index.js'
-import { findEquivalentCarCids, asPieceCidV1, asPieceCidV2 } from '../piece.js'
+import { findEquivalentCids, asPieceCidV1, asPieceCidV2 } from '../piece.js'
 import { getEnv, parseQueryStringParameters } from '../utils.js'
 
 Sentry.AWSLambda.init({
@@ -73,17 +73,17 @@ async function resolveContent (cid, locateContent) {
  * @param {(cid: CID) => Promise<string | undefined> } locateContent
  */
 async function resolvePiece (cid, locateContent) {
-  const cars = await findEquivalentCarCids(cid)
-  if (cars.size === 0) {
-    return { statusCode: 404, body: 'No equivalent CAR CID for Piece CID found' }
+  const cids = await findEquivalentCids(cid)
+  if (cids.size === 0) {
+    return { statusCode: 404, body: 'No equivalent CID for Piece CID found' }
   }
-  for (const cid of cars) {
+  for (const cid of cids) {
     const url = await locateContent(cid)
     if (url) {
       return redirectTo(url)
     }
   }
-  return { statusCode: 404, body: 'No CARs found for Piece CID' }
+  return { statusCode: 404, body: 'No content found for Piece CID' }
 }
 
 /**

--- a/roundabout/piece.js
+++ b/roundabout/piece.js
@@ -19,7 +19,6 @@ export const PIECE_V2_MULTIHASH = 0x10_11
 
 /** 
  * @typedef {import('multiformats/cid').CID} CID
- * @typedef {import('@web3-storage/w3up-client/types').CARLink} CARLink
  * @typedef {import('@web3-storage/content-claims/client/api').Claim} Claim
  **/
 
@@ -57,13 +56,13 @@ export function asCarCid(cid) {
 }
 
 /**
- * Find the set of CAR CIDs that are claimed to be equivalent to the Piece CID.
+ * Find the set of CIDs that are claimed to be equivalent to the Piece CID.
  * 
  * @param {CID} piece
  * @param {(CID) => Promise<Claim[]>} [fetchClaims] - returns content claims for a cid
  */
-export async function findEquivalentCarCids (piece, fetchClaims = createClaimsClientForEnv()) {
-  /** @type {Set<CARLink>} */
+export async function findEquivalentCids (piece, fetchClaims = createClaimsClientForEnv()) {
+  /** @type {Set<import('multiformats').UnknownLink>} */
   const cids = new Set()
   const claims = await fetchClaims(piece)
   for (const claim of claims) {
@@ -72,11 +71,9 @@ export async function findEquivalentCarCids (piece, fetchClaims = createClaimsCl
       continue
     }
     // an equivalence claim may have the pieceCid as the content cid _or_ the equals cid
-    // so check both properties for the car cid.
-    const carCid = asCarCid(claim.equals) ?? asCarCid(claim.content)
-    if (carCid) {
-      cids.add(carCid)
-    }
+    // so if content does not equal piece, we can grab the content. Otherwise equals
+    const equivalentCid = !claim.content.equals(piece) ? claim.content : claim.equals
+    cids.add(equivalentCid)
   }
   return cids
 }

--- a/roundabout/piece.js
+++ b/roundabout/piece.js
@@ -72,7 +72,7 @@ export async function findEquivalentCids (piece, fetchClaims = createClaimsClien
     }
     // an equivalence claim may have the pieceCid as the content cid _or_ the equals cid
     // so if content does not equal piece, we can grab the content. Otherwise equals
-    const equivalentCid = !claim.content.equals(piece) ? claim.content : claim.equals
+    const equivalentCid = claim.content.equals(piece) ? claim.equals : claim.content
     cids.add(equivalentCid)
   }
   return cids

--- a/roundabout/test/piece.test.js
+++ b/roundabout/test/piece.test.js
@@ -4,14 +4,14 @@ import * as Raw from 'multiformats/codecs/raw'
 import { sha256 } from 'multiformats/hashes/sha2'
 import * as Digest from 'multiformats/hashes/digest'
 import { Piece, MIN_PAYLOAD_SIZE } from '@web3-storage/data-segment'
-import { findEquivalentCarCids, asCarCid, asPieceCidV1, asPieceCidV2, CAR_CODE } from '../piece.js'
+import { findEquivalentCids, asCarCid, asPieceCidV1, asPieceCidV2, CAR_CODE } from '../piece.js'
 
-test('findEquivalentCarCids', async t => {
+test('findEquivalentCids', async t => {
   const bytes = new Uint8Array(MIN_PAYLOAD_SIZE)
   const pieceCid = Piece.fromPayload(bytes).link
   const carCid = CID.createV1(CAR_CODE, sha256.digest(bytes))
   const rawCid = CID.createV1(Raw.code, sha256.digest(bytes))
-  const carSet = await findEquivalentCarCids(pieceCid, async () => {
+  const carSet = await findEquivalentCids(pieceCid, async () => {
     return [
       { type: 'assert/equals', content: pieceCid, equals: carCid }, // yes! is equivalent carCid
       { type: 'assert/equals', content: carCid, equals: pieceCid }, // no: is duplicate
@@ -23,10 +23,10 @@ test('findEquivalentCarCids', async t => {
   t.is([...carSet].at(0).toString(), carCid.toString())
 })
 
-test('findEquivalentCarCids from content-claims api', async t => {
+test('findEquivalentCids from content-claims api', async t => {
   const pieceCid = CID.parse('bafkzcibbai3tdo4zvruj6zxo6wlt4suu3imi6to4vzmaojh4n475mdp5jcbtg')
   const carCid = CID.parse('bagbaieratdhefxxpkhkae2ovil2tcs7pfr2grvabvvoykful7k2maeepox3q')
-  const carSet = await findEquivalentCarCids(pieceCid)
+  const carSet = await findEquivalentCids(pieceCid)
   let found
   for (const cid of carSet) {
     if (cid.toString() === carCid.toString()) {

--- a/roundabout/test/piece.test.js
+++ b/roundabout/test/piece.test.js
@@ -15,11 +15,11 @@ test('findEquivalentCids', async t => {
     return [
       { type: 'assert/equals', content: pieceCid, equals: carCid }, // yes! is equivalent carCid
       { type: 'assert/equals', content: carCid, equals: pieceCid }, // no: is duplicate
-      { type: 'assert/equals', content: pieceCid, equals: rawCid }, // no: pieceCId not mapped to carCid
+      { type: 'assert/equals', content: pieceCid, equals: rawCid }, // yes! pieceCId mapped to rawCid
       { type: 'assert/location', content: pieceCid, location: `ipfs://${carCid}` }, // no: is not equals claim
     ]
   })
-  t.is(carSet.size, 1, 'should return 1 unique carCid')
+  t.is(carSet.size, 2, 'should return mapped CIDs')
   t.is([...carSet].at(0).toString(), carCid.toString())
 })
 


### PR DESCRIPTION
We should keep also equivalent CIDs that are not CARs to attempt in the bucket to get presigned URL

We will try for each of them to check if it is in bucket and generate presigned URL per:
- https://github.com/web3-storage/w3infra/blob/fix/find-equivalent-cids-also-if-not-car-cid/roundabout/functions/redirect.js#L81C23-L81C36
- https://github.com/web3-storage/w3infra/blob/fix/find-equivalent-cids-also-if-not-car-cid/roundabout/index.js#L25