### PR TITLE
fix: re-enable integration tests filecoin

### DIFF
--- a/test/filecoin.test.js
+++ b/test/filecoin.test.js
@@ -32,7 +32,7 @@ test.before(t => {
   }
 })
 
-test.skip('w3filecoin integration flow', async t => {
+test('w3filecoin integration flow', async t => {
   const s3Client = getAwsBucketClient()
   const s3ClientFilecoin = getAwsBucketClient('us-east-2')
   const inbox = await createMailSlurpInbox()


### PR DESCRIPTION
Did https://github.com/web3-storage/w3filecoin-infra/pull/89 to make aggregates more fast to get as they are smaller. Because of the extra new piece, I suspect some pieces were left behind