### PR TITLE
fix: roundabout should just redirect to 404 presigned url when no car in bucket instead of redundant check

### DIFF
--- a/roundabout/index.js
+++ b/roundabout/index.js
@@ -1,8 +1,5 @@
 import { getSignedUrl as getR2SignedUrl } from "@aws-sdk/s3-request-presigner"
-import {
-  GetObjectCommand,
-  HeadObjectCommand
-} from "@aws-sdk/client-s3"
+import { GetObjectCommand } from "@aws-sdk/client-s3"
 
 /**
  * @typedef {import('@aws-sdk/client-s3').S3Client} S3Client
@@ -21,20 +18,6 @@ export function getSigner (s3Client, bucketName) {
      * @param {RequestPresigningArguments} [options]
      */
     getUrl: async (key, options) => {
-      // Validate bucket has requested cid
-      const headCommand = new HeadObjectCommand({
-        Bucket: bucketName,
-        Key: key,
-      })
-      try {
-        await s3Client.send(headCommand)
-      } catch (err) {
-        if (err?.$metadata?.httpStatusCode === 404) {
-          return
-        }
-        throw new Error(`Failed to HEAD object in bucket for: ${key}`)
-      }
-
       const signedUrl = await getR2SignedUrl(
         s3Client,
         new GetObjectCommand({


### PR DESCRIPTION
@ribasushi did some profiling and roundabout is taking ~800ms just to return the 302 status code (when requesting bytes by PieceCID). Probably most of this time comes from waiting on the content claims response, but also looking into what else Roundabout handler does, it may be a good idea to just redirect to the presigned url without validating content is in the bucket. We save one request to the bucket, and given we only use roundabout in internal cases it should never be 404. But actually if it is 404, might make more sense to then have presigned url response to be 404 than server to throw an error.

Thoughts?