### PR TITLE
feat: add snapshot size to dry run report

### DIFF
--- a/billing/scripts/helpers.js
+++ b/billing/scripts/helpers.js
@@ -45,7 +45,8 @@ const TB = 1024 * GB
 const productInfo = {
   'did:web:starter.web3.storage': { cost: 0, overage: 0.15 / GB, included: 5 * GB },
   'did:web:lite.web3.storage': { cost: 10, overage: 0.05 / GB, included: 100 * GB },
-  'did:web:business.web3.storage': { cost: 100, overage: 0.03 / GB, included: 2 * TB }
+  'did:web:business.web3.storage': { cost: 100, overage: 0.03 / GB, included: 2 * TB },
+  'did:web:free.web3.storage': { cost: 0, overage: 0 / GB, included: 0 }
 }
 
 /**

--- a/stacks/filecoin-stack.js
+++ b/stacks/filecoin-stack.js
@@ -52,7 +52,13 @@ export function FilecoinStack({ stack, app }) {
   const filecoinSubmitQueueDLQ = new Queue(stack, `${filecoinSubmitQueueName}-dlq`, {
     cdk: { queue: { retentionPeriod: Duration.days(14) } }
    })
-  const filecoinSubmitQueue = new Queue(stack, filecoinSubmitQueueName)
+  const filecoinSubmitQueue = new Queue(stack, filecoinSubmitQueueName, {
+    cdk: {
+      queue: {
+        visibilityTimeout: Duration.seconds(15 * 60)
+      }
+    }
+  })
   filecoinSubmitQueue.addConsumer(stack, {
     function: {
       handler: 'filecoin/functions/handle-filecoin-submit-message.main',


### PR DESCRIPTION
This adds space size (in bytes) to the dry run report.

Also adds the new `did:web:free.web3.storage` plan (that NFT.Storage is using) to the pricing calculator.