### PR TITLE
feat(roundabout): add `/piece/{pieceCID}` redirect endpoint

### DIFF
--- a/roundabout/CLAUDE.md
+++ b/roundabout/CLAUDE.md
@@ -1,0 +1,177 @@
+# Roundabout Module
+
+This file provides guidance for AI agents working with the `roundabout` package.
+
+---
+
+## Overview
+
+Roundabout is a **content redirection service** — an HTTP gateway that resolves CIDs (Content Identifiers) to time-limited signed URLs pointing to the actual stored content.
+
+Given a CID, it:
+1. Determines what type of CID it is (CAR, RAW blob, or Piece CID)
+2. Queries the Indexing Service for location claims (for RAW/Piece CIDs)
+3. Generates a presigned R2/S3 URL for the content
+4. Returns an HTTP 302 redirect to that signed URL
+
+It is also used by the Filecoin pipeline (`filecoin-stack.js`) as the `CONTENT_STORE_HTTP_ENDPOINT` — the URL clients use to fetch stored content.
+
+---
+
+## File Structure
+
+```
+roundabout/
+├── index.js              # Core factories: getSigner(), contentLocationResolver()
+├── piece.js              # Piece CID detection and equivalence resolution
+├── utils.js              # Query string parsing, env loading, CID type checks
+├── constants.js          # CID codec/multihash codes, CARPARK_DOMAIN
+├── functions/
+│   └── redirect.js       # Lambda handlers: redirectGet(), redirectKeyGet()
+└── test/
+    ├── index.test.js     # Integration tests for signer and content resolution
+    ├── piece.test.js     # Unit tests for Piece CID functions
+    └── helpers/
+        ├── context.js    # AVA test context definition (s3Client)
+        └── resources.js  # MinIO S3 container setup, bucket creation
+```
+
+---
+
+## HTTP API
+
+Two Lambda handlers are exposed via API Gateway:
+
+| Method | Route | Handler | Description |
+|--------|-------|---------|-------------|
+| `GET/HEAD` | `/{cid}` | `redirect.handler` | Resolve CID → presigned URL redirect |
+| `GET/HEAD` | `/key/{key}` | `redirect.keyHandler` | Direct bucket key → presigned URL redirect |
+
+### `GET /{cid}` — CID Resolution Flow
+
+1. Parse CID from path
+2. Parse `expires` query param (1s–7 days, default 3 days)
+3. Determine CID type:
+   - **Piece V2** → query Indexing Service for equivalent CIDs (e.g., CAR CID), then resolve content
+   - **Piece V1** → return 415 Unsupported
+   - **CAR / RAW** → resolve directly via `contentLocationResolver()`
+4. Return 302 redirect to presigned URL, or 404 if not found
+
+### `GET /key/{key}` — Direct Key Access
+
+Skips CID resolution. Validates bucket name (whitelist: `['dagcargo']`) and returns a presigned URL for the raw bucket key.
+
+---
+
+## Core Functions
+
+### `index.js`
+
+**`getSigner(s3Client, bucketName)`**
+- Returns a `{ getUrl(key, options) }` object
+- Generates presigned `GetObject` URLs via AWS SDK S3 presigner
+
+**`contentLocationResolver({ s3Client, bucket, expiresIn, indexingService })`**
+- Returns an async `locateContent(cid)` function
+- For **CAR CIDs**: signs `{cid}/{cid}.car` in the bucket
+- For **RAW CIDs**: queries Indexing Service for `assert/location` claims; if URL matches carpark domain, signs it; otherwise returns the raw location URL
+
+### `piece.js`
+
+**`asPieceCidV2(cid)`** / **`asPieceCidV1(cid)`**
+- Detects Piece CID versions by inspecting codec and multihash codes
+- Returns the typed CID or `undefined`
+
+**`findEquivalentCids(piece, indexingService?)`**
+- Queries Indexing Service for `assert/equals` claims for the given Piece CID
+- Returns a `Set` of equivalent CIDs (e.g., the corresponding CAR CID)
+- Used by `redirectGet()` to resolve Piece V2 → CAR → signed URL
+
+**`createIndexingServiceClient(env?)`**
+- Instantiates the Indexing Service client
+- Defaults to production; uses staging for non-prod SST stages
+
+### `utils.js`
+
+**`parseQueryStringParameters(queryParams)`**
+- Validates `expires` (1–604800 seconds, default: 259200 = 3 days)
+- Validates `bucket` (whitelist: `['dagcargo']`)
+
+**`getEnv()`**
+- Validates and returns required env vars: `BUCKET_ENDPOINT`, `BUCKET_REGION`, `BUCKET_NAME`, `BUCKET_ACCESS_KEY_ID`, `BUCKET_SECRET_ACCESS_KEY`
+
+### `constants.js`
+
+| Constant | Value | Purpose |
+|----------|-------|---------|
+| `RAW_CODE` | `0x55` | Raw codec multicode |
+| `CAR_CODE` | `0x0202` | CAR codec code |
+| `PIECE_V1_CODE` | `0xf101` | Piece V1 codec |
+| `PIECE_V1_MULTIHASH` | `0x1012` | Piece V1 multihash |
+| `PIECE_V2_MULTIHASH` | `0x1011` | Piece V2 multihash |
+| `CARPARK_DOMAIN` | dynamic | R2 carpark public domain (e.g., `carpark-prod-0.r2.w3s.link`) |
+
+---
+
+## External Dependencies
+
+| Service | Package | Usage |
+|---------|---------|-------|
+| R2 / S3 | `@aws-sdk/client-s3`, `@aws-sdk/s3-request-presigner` | Presign `GetObject` URLs for stored content |
+| Indexing Service | `@storacha/indexing-service-client` | Query `assert/location` and `assert/equals` claims |
+| Sentry | `@sentry/serverless` | Lambda error tracking |
+
+---
+
+## Environment Variables
+
+Set via SST and passed to Lambda at deploy time (see `stacks/roundabout-stack.js`):
+
+| Variable | Description |
+|----------|-------------|
+| `BUCKET_ENDPOINT` | R2 API endpoint |
+| `BUCKET_REGION` | e.g., `us-west-2` or `auto` |
+| `BUCKET_NAME` | e.g., `dagcargo` |
+| `BUCKET_ACCESS_KEY_ID` | R2 credentials |
+| `BUCKET_SECRET_ACCESS_KEY` | R2 credentials |
+| `ROUNDABOUT_INDEXING_SERVICE_URLS` | JSON array of Indexing Service URLs (supports multiple for combining) |
+
+Optional:
+- `ROUNDABOUT_API_URL` — use a pre-deployed API instead of creating a new one
+- `ROUNDABOUT_HOSTED_ZONE` — custom domain setup
+
+---
+
+## Deployment
+
+Defined in `stacks/roundabout-stack.js`. Deployed as an SST API Gateway HTTP API backed by two Lambda functions (`handler`, `keyHandler`). Exports `roundaboutApiUrl` consumed by `filecoin-stack.js` as `CONTENT_STORE_HTTP_ENDPOINT`.
+
+---
+
+## Testing
+
+Framework: **AVA** with **MinIO** (via testcontainers) for local S3 emulation.
+
+```bash
+# Requires Docker Desktop running
+export AWS_REGION='us-west-2' AWS_ACCESS_KEY_ID='NOSUCH' AWS_SECRET_ACCESS_KEY='NOSUCH'
+pnpm test -w roundabout
+```
+
+- `index.test.js` — integration tests: spins up MinIO, puts objects, validates presigned URLs end-to-end
+- `piece.test.js` — unit tests: CID type detection, claim equivalence resolution with mocked client
+
+### Test Helpers
+
+- `test/helpers/resources.js` — `createS3()` starts MinIO container, `createBucket()` creates a random bucket
+- `test/helpers/context.js` — typed AVA context with `s3Client`
+
+---
+
+## Key Design Patterns
+
+- **Factory functions**: `getSigner()` and `contentLocationResolver()` return closures; pass config once, call many times.
+- **CID type discrimination**: codec + multihash codes identify CAR vs RAW vs Piece CIDs — do not use string-based checks.
+- **Claim-based resolution**: RAW and Piece CIDs rely entirely on Indexing Service claims for location; there is no internal registry.
+- **Presigned URLs only**: content bytes are never proxied through roundabout — clients always follow the redirect to R2 directly.
+- **Multi-client combining**: `ROUNDABOUT_INDEXING_SERVICE_URLS` supports multiple URLs; the Lambda combines them for redundancy.

--- a/roundabout/functions/redirect.js
+++ b/roundabout/functions/redirect.js
@@ -36,7 +36,7 @@ export async function redirectGet(request) {
   }
 
   /** @type {string[]} */
-  const indexingServiceURLs = JSON.parse(process.env.ROUNDABOUT_INDEXING_SERVICE_URLS || '["https://indexer.storacha.network"]')
+  const indexingServiceURLs = JSON.parse(process.env.ROUNDABOUT_INDEXING_SERVICE_URLS || '[]')
   if (!indexingServiceURLs.length && process.env.SST_STAGE !== 'prod') {
     indexingServiceURLs.push('https://staging.indexer.storacha.network')
   }
@@ -138,7 +138,7 @@ export async function redirectPieceGet(request) {
   }
 
   /** @type {string[]} */
-   const indexingServiceURLs = JSON.parse(process.env.ROUNDABOUT_INDEXING_SERVICE_URLS || '["https://indexer.storacha.network"]')
+   const indexingServiceURLs = JSON.parse(process.env.ROUNDABOUT_INDEXING_SERVICE_URLS || '[]')
   if (!indexingServiceURLs.length && process.env.SST_STAGE !== 'prod') {
     indexingServiceURLs.push('https://staging.indexer.storacha.network')
   }

--- a/roundabout/functions/redirect.js
+++ b/roundabout/functions/redirect.js
@@ -36,7 +36,7 @@ export async function redirectGet(request) {
   }
 
   /** @type {string[]} */
-  const indexingServiceURLs = JSON.parse(process.env.ROUNDABOUT_INDEXING_SERVICE_URLS || '[]')
+  const indexingServiceURLs = JSON.parse(process.env.ROUNDABOUT_INDEXING_SERVICE_URLS || '["https://indexer.storacha.network"]')
   if (!indexingServiceURLs.length && process.env.SST_STAGE !== 'prod') {
     indexingServiceURLs.push('https://staging.indexer.storacha.network')
   }
@@ -59,21 +59,7 @@ export async function redirectGet(request) {
 
   let response
   if (asPieceCidV2(cid) !== undefined) {
-    // For piece CIDs, try multiple buckets in production
-    const locateContents = []
-    const baseBucketName = getEnv().BUCKET_NAME
-    const bucketNames = getBucketNamesToTry(baseBucketName)
-
-    for (const bucketName of bucketNames) {
-      locateContents.push(contentLocationResolver({
-        bucket: bucketName,
-        s3Client: getBucketClient(),
-        expiresIn,
-        indexingService
-      }))
-    }
-    
-    response = await resolvePiece(cid, locateContents, indexingService)
+    response = await resolvePiece(cid, locateContent, indexingService)
   } else if (asPieceCidV1(cid) !== undefined) {
     response = {
       statusCode: 415,
@@ -87,27 +73,6 @@ export async function redirectGet(request) {
     statusCode: 415, 
     body: 'Unsupported CID type' 
   }
-}
-
-/**
- * Get the list of bucket names to try for content location resolution.
- * In production, tries both primary and secondary carpark buckets.
- * 
- * @param {string} baseBucketName
- * @returns {string[]}
- */
-function getBucketNamesToTry(baseBucketName) {
-  const bucketNames = [baseBucketName]
-  if (process.env.SST_STAGE === 'prod') {
-    if (/^carpark-\w+-0$/.test(baseBucketName)) {
-      const secondaryBucket = baseBucketName.replace(/-0$/, '-1')
-      bucketNames.push(secondaryBucket)
-    } else if (/^carpark-\w+-1$/.test(baseBucketName)) {
-      const primaryBucket = baseBucketName.replace(/-1$/, '-0')
-      bucketNames.unshift(primaryBucket)
-    }
-  }
-  return bucketNames
 }
 
 /**
@@ -128,20 +93,18 @@ async function resolveContent (cid, locateContent) {
  * Return response for a Piece CID, or undefined for other CID types
  * 
  * @param {UnknownLink} cid
- * @param {((cid: UnknownLink) => Promise<string | undefined>)[]} locateContents
+ * @param {(cid: UnknownLink) => Promise<string | undefined> } locateContent
  * @param {IndexingServiceQueryClient} [indexingService]
  */
-async function resolvePiece (cid, locateContents, indexingService) {
+async function resolvePiece (cid, locateContent, indexingService) {
   const cids = await findEquivalentCids(cid, indexingService)
   if (cids.size === 0) {
     return { statusCode: 404, body: 'No equivalent CID for Piece CID found' }
   }
   for (const cid of cids) {
-    for (const locateContent of locateContents) {
-      const url = await locateContent(cid)
-      if (url) {
-        return redirectTo(url)
-      }
+    const url = await locateContent(cid)
+    if (url) {
+      return redirectTo(url)
     }
   }
   return { statusCode: 404, body: 'No content found for Piece CID' }
@@ -175,7 +138,7 @@ export async function redirectPieceGet(request) {
   }
 
   /** @type {string[]} */
-  const indexingServiceURLs = JSON.parse(process.env.ROUNDABOUT_INDEXING_SERVICE_URLS || '[]')
+   const indexingServiceURLs = JSON.parse(process.env.ROUNDABOUT_INDEXING_SERVICE_URLS || '["https://indexer.storacha.network"]')
   if (!indexingServiceURLs.length && process.env.SST_STAGE !== 'prod') {
     indexingServiceURLs.push('https://staging.indexer.storacha.network')
   }
@@ -189,20 +152,14 @@ export async function redirectPieceGet(request) {
     indexingService = new Client({ serviceURL: url })
   }
 
-  const locateContents = []
-  const baseBucketName = getEnv().BUCKET_NAME
-  const bucketNames = getBucketNamesToTry(baseBucketName)
+  const locateContent = contentLocationResolver({
+    bucket: getEnv().BUCKET_NAME,
+    s3Client: getBucketClient(),
+    expiresIn,
+    indexingService
+  })
 
-  for (const bucketName of bucketNames) {
-    locateContents.push(contentLocationResolver({
-      bucket: bucketName,
-      s3Client: getBucketClient(),
-      expiresIn,
-      indexingService
-    }))
-  }
-
-  return resolvePiece(cid, locateContents, indexingService)
+  return resolvePiece(cid, locateContent, indexingService)
 }
 
 /**

--- a/roundabout/functions/redirect.js
+++ b/roundabout/functions/redirect.js
@@ -36,7 +36,7 @@ export async function redirectGet(request) {
   }
 
   /** @type {string[]} */
-  const indexingServiceURLs = JSON.parse(process.env.ROUNDABOUT_INDEXING_SERVICE_URLS || '["https://indexer.storacha.network"]')
+  const indexingServiceURLs = JSON.parse(process.env.ROUNDABOUT_INDEXING_SERVICE_URLS || '[]')
   if (!indexingServiceURLs.length && process.env.SST_STAGE !== 'prod') {
     indexingServiceURLs.push('https://staging.indexer.storacha.network')
   }
@@ -59,7 +59,21 @@ export async function redirectGet(request) {
 
   let response
   if (asPieceCidV2(cid) !== undefined) {
-    response = await resolvePiece(cid, locateContent, indexingService)
+    // For piece CIDs, try multiple buckets in production
+    const locateContents = []
+    const baseBucketName = getEnv().BUCKET_NAME
+    const bucketNames = getBucketNamesToTry(baseBucketName)
+
+    for (const bucketName of bucketNames) {
+      locateContents.push(contentLocationResolver({
+        bucket: bucketName,
+        s3Client: getBucketClient(),
+        expiresIn,
+        indexingService
+      }))
+    }
+    
+    response = await resolvePiece(cid, locateContents, indexingService)
   } else if (asPieceCidV1(cid) !== undefined) {
     response = {
       statusCode: 415,
@@ -73,6 +87,27 @@ export async function redirectGet(request) {
     statusCode: 415, 
     body: 'Unsupported CID type' 
   }
+}
+
+/**
+ * Get the list of bucket names to try for content location resolution.
+ * In production, tries both primary and secondary carpark buckets.
+ * 
+ * @param {string} baseBucketName
+ * @returns {string[]}
+ */
+function getBucketNamesToTry(baseBucketName) {
+  const bucketNames = [baseBucketName]
+  if (process.env.SST_STAGE === 'prod') {
+    if (/^carpark-\w+-0$/.test(baseBucketName)) {
+      const secondaryBucket = baseBucketName.replace(/-0$/, '-1')
+      bucketNames.push(secondaryBucket)
+    } else if (/^carpark-\w+-1$/.test(baseBucketName)) {
+      const primaryBucket = baseBucketName.replace(/-1$/, '-0')
+      bucketNames.unshift(primaryBucket)
+    }
+  }
+  return bucketNames
 }
 
 /**
@@ -93,18 +128,20 @@ async function resolveContent (cid, locateContent) {
  * Return response for a Piece CID, or undefined for other CID types
  * 
  * @param {UnknownLink} cid
- * @param {(cid: UnknownLink) => Promise<string | undefined> } locateContent
+ * @param {((cid: UnknownLink) => Promise<string | undefined>)[]} locateContents
  * @param {IndexingServiceQueryClient} [indexingService]
  */
-async function resolvePiece (cid, locateContent, indexingService) {
+async function resolvePiece (cid, locateContents, indexingService) {
   const cids = await findEquivalentCids(cid, indexingService)
   if (cids.size === 0) {
     return { statusCode: 404, body: 'No equivalent CID for Piece CID found' }
   }
   for (const cid of cids) {
-    const url = await locateContent(cid)
-    if (url) {
-      return redirectTo(url)
+    for (const locateContent of locateContents) {
+      const url = await locateContent(cid)
+      if (url) {
+        return redirectTo(url)
+      }
     }
   }
   return { statusCode: 404, body: 'No content found for Piece CID' }
@@ -138,7 +175,7 @@ export async function redirectPieceGet(request) {
   }
 
   /** @type {string[]} */
-   const indexingServiceURLs = JSON.parse(process.env.ROUNDABOUT_INDEXING_SERVICE_URLS || '["https://indexer.storacha.network"]')
+  const indexingServiceURLs = JSON.parse(process.env.ROUNDABOUT_INDEXING_SERVICE_URLS || '[]')
   if (!indexingServiceURLs.length && process.env.SST_STAGE !== 'prod') {
     indexingServiceURLs.push('https://staging.indexer.storacha.network')
   }
@@ -152,14 +189,20 @@ export async function redirectPieceGet(request) {
     indexingService = new Client({ serviceURL: url })
   }
 
-  const locateContent = contentLocationResolver({
-    bucket: getEnv().BUCKET_NAME,
-    s3Client: getBucketClient(),
-    expiresIn,
-    indexingService
-  })
+  const locateContents = []
+  const baseBucketName = getEnv().BUCKET_NAME
+  const bucketNames = getBucketNamesToTry(baseBucketName)
 
-  return resolvePiece(cid, locateContent, indexingService)
+  for (const bucketName of bucketNames) {
+    locateContents.push(contentLocationResolver({
+      bucket: bucketName,
+      s3Client: getBucketClient(),
+      expiresIn,
+      indexingService
+    }))
+  }
+
+  return resolvePiece(cid, locateContents, indexingService)
 }
 
 /**

--- a/roundabout/functions/redirect.js
+++ b/roundabout/functions/redirect.js
@@ -36,7 +36,7 @@ export async function redirectGet(request) {
   }
 
   /** @type {string[]} */
-  const indexingServiceURLs = JSON.parse(process.env.ROUNDABOUT_INDEXING_SERVICE_URLS ?? '[]')
+  const indexingServiceURLs = JSON.parse(process.env.ROUNDABOUT_INDEXING_SERVICE_URLS || '["https://indexer.storacha.network"]')
   if (!indexingServiceURLs.length && process.env.SST_STAGE !== 'prod') {
     indexingServiceURLs.push('https://staging.indexer.storacha.network')
   }
@@ -108,6 +108,58 @@ async function resolvePiece (cid, locateContent, indexingService) {
     }
   }
   return { statusCode: 404, body: 'No content found for Piece CID' }
+}
+
+/**
+ * AWS HTTP Gateway handler for GET /piece/{pieceCID} by Piece CID (V2 only)
+ *
+ * @param {import('aws-lambda').APIGatewayProxyEventV2} request
+ */
+export async function redirectPieceGet(request) {
+  let cid, expiresIn
+  try {
+    const parsedQueryParams = parseQueryStringParameters(request.queryStringParameters)
+    expiresIn = parsedQueryParams.expiresIn
+    const cidString = request.pathParameters?.pieceCID
+    cid = CID.parse(cidString || '')
+  } catch (/** @type {any} */ err) {
+    return { statusCode: 400, body: err.message }
+  }
+
+  if (asPieceCidV1(cid) !== undefined) {
+    return {
+      statusCode: 415,
+      body: 'v1 Piece CIDs are not supported yet. Please provide a V2 Piece CID. https://github.com/filecoin-project/FIPs/blob/master/FRCs/frc-0069.md'
+    }
+  }
+
+  if (asPieceCidV2(cid) === undefined) {
+    return { statusCode: 400, body: 'Invalid Piece CID. Expected a V2 Piece CID.' }
+  }
+
+  /** @type {string[]} */
+   const indexingServiceURLs = JSON.parse(process.env.ROUNDABOUT_INDEXING_SERVICE_URLS || '["https://indexer.storacha.network"]')
+  if (!indexingServiceURLs.length && process.env.SST_STAGE !== 'prod') {
+    indexingServiceURLs.push('https://staging.indexer.storacha.network')
+  }
+
+  let indexingService
+  if (indexingServiceURLs.length > 1) {
+    const clients = indexingServiceURLs.map(u => new Client({ serviceURL: new URL(u) }))
+    indexingService = combine(clients)
+  } else {
+    const url = indexingServiceURLs[0] ? new URL(indexingServiceURLs[0]) : undefined
+    indexingService = new Client({ serviceURL: url })
+  }
+
+  const locateContent = contentLocationResolver({
+    bucket: getEnv().BUCKET_NAME,
+    s3Client: getBucketClient(),
+    expiresIn,
+    indexingService
+  })
+
+  return resolvePiece(cid, locateContent, indexingService)
 }
 
 /**
@@ -189,4 +241,5 @@ function getBucketClient () {
 }
 
 export const handler = Sentry.AWSLambda.wrapHandler(redirectGet)
+export const pieceHandler = Sentry.AWSLambda.wrapHandler(redirectPieceGet)
 export const keyHandler = Sentry.AWSLambda.wrapHandler(redirectKeyGet)

--- a/stacks/roundabout-stack.js
+++ b/stacks/roundabout-stack.js
@@ -38,10 +38,12 @@ export function RoundaboutStack({ stack, app }) {
       }
     },
     routes: {
-      'GET /{cid}':       'roundabout/functions/redirect.handler',
-      'HEAD /{cid}':      'roundabout/functions/redirect.handler',
-      'GET /key/{key}':   'roundabout/functions/redirect.keyHandler',
-      'HEAD /key/{key}':   'roundabout/functions/redirect.keyHandler',
+      'GET /piece/{pieceCID}':  'roundabout/functions/redirect.pieceHandler',
+      'HEAD /piece/{pieceCID}': 'roundabout/functions/redirect.pieceHandler',
+      'GET /{cid}':             'roundabout/functions/redirect.handler',
+      'HEAD /{cid}':            'roundabout/functions/redirect.handler',
+      'GET /key/{key}':         'roundabout/functions/redirect.keyHandler',
+      'HEAD /key/{key}':        'roundabout/functions/redirect.keyHandler',
     },
     accessLog: {
       format:'{"requestTime":"$context.requestTime","requestId":"$context.requestId","httpMethod":"$context.httpMethod","path":"$context.path","routeKey":"$context.routeKey","status":$context.status,"responseLatency":$context.responseLatency,"integrationRequestId":"$context.integration.requestId","integrationStatus":"$context.integration.status","integrationLatency":"$context.integration.latency","integrationServiceStatus":"$context.integration.integrationStatus","ip":"$context.identity.sourceIp","userAgent":"$context.identity.userAgent"}'

--- a/stacks/roundabout-stack.js
+++ b/stacks/roundabout-stack.js
@@ -38,12 +38,10 @@ export function RoundaboutStack({ stack, app }) {
       }
     },
     routes: {
-      'GET /piece/{pieceCID}':  'roundabout/functions/redirect.pieceHandler',
-      'HEAD /piece/{pieceCID}': 'roundabout/functions/redirect.pieceHandler',
-      'GET /{cid}':             'roundabout/functions/redirect.handler',
-      'HEAD /{cid}':            'roundabout/functions/redirect.handler',
-      'GET /key/{key}':         'roundabout/functions/redirect.keyHandler',
-      'HEAD /key/{key}':        'roundabout/functions/redirect.keyHandler',
+      'GET /{cid}':       'roundabout/functions/redirect.handler',
+      'HEAD /{cid}':      'roundabout/functions/redirect.handler',
+      'GET /key/{key}':   'roundabout/functions/redirect.keyHandler',
+      'HEAD /key/{key}':   'roundabout/functions/redirect.keyHandler',
     },
     accessLog: {
       format:'{"requestTime":"$context.requestTime","requestId":"$context.requestId","httpMethod":"$context.httpMethod","path":"$context.path","routeKey":"$context.routeKey","status":$context.status,"responseLatency":$context.responseLatency,"integrationRequestId":"$context.integration.requestId","integrationStatus":"$context.integration.status","integrationLatency":"$context.integration.latency","integrationServiceStatus":"$context.integration.integrationStatus","ip":"$context.identity.sourceIp","userAgent":"$context.identity.userAgent"}'


### PR DESCRIPTION
Adds a dedicated GET/HEAD `/piece/{pieceCID}` route that resolves a Piece V2 CID to a presigned content URL via the Indexing Service, returning a `302` redirect. Returns `415` for Piece V1 CIDs and `400`for non-piece CIDs.   